### PR TITLE
Remove line breaks in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,21 @@
 
 Register and manage your Kubernetes Services to a Service Registry.
 
-The CN-WAN Operator is part of the Cloud Native SD-WAN (CN-WAN) project.
-Please check the
-[CN-WAN documentation](https://github.com/CloudNativeSDWAN/cnwan-docs) for the
-general project overview and architecture.
-You can contact the CN-WAN team at [cnwan@cisco.com](mailto:cnwan@cisco.com).
+The CN-WAN Operator is part of the Cloud Native SD-WAN (CN-WAN) project. Please check the [CN-WAN documentation](https://github.com/CloudNativeSDWAN/cnwan-docs) for the general project overview and architecture. You can contact the CN-WAN team at [cnwan@cisco.com](mailto:cnwan@cisco.com).
 
 ## Overview
 
-CN-WAN Operator is a Kubernetes operator created with [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
-that watches for changes in services deployed in your cluster and registers
-them to a service registry so that clients can later discover all registered
-services and know how to connect to them properly.
+CN-WAN Operator is a Kubernetes operator created with [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) that watches for changes in services deployed in your cluster and registers them to a service registry so that clients can later discover all registered services and know how to connect to them properly.
 
-The service registry is populated with only the allowed resources and
-properties, as specified from a configuration file.
+The service registry is populated with only the allowed resources and properties, as specified from a configuration file.
 
 ## Supported Service Registries
 
-Currently, the CN-WAN Operator can register and manage Kubernetes services to
-Google Cloud's [Service Directory](https://cloud.google.com/service-directory).
-The project and region must be provided in the `ConfigMap`, and the service
-account file must be provided as a `Secret`.  
-Please follow [this section](#configure-the-operator) to learn how to set up
-the operator and provide such files.
+Currently, the CN-WAN Operator can register and manage Kubernetes services to Google Cloud's [Service Directory](https://cloud.google.com/service-directory). The project and region must be provided in the `ConfigMap`, and the service account file must be provided as a `Secret`.  Please follow [this section](#configure-the-operator) to learn how to set up the operator and provide such files.
 
 ## Try It Out
 
-If you want to quickly see how CN-WAN Operator works, you can follow this simple
-step by step [quickstart](./docs/quickstart.md) guide.
+If you want to quickly see how CN-WAN Operator works, you can follow this simple step by step [quickstart](./docs/quickstart.md) guide.
 
 ## Documentation
 

--- a/docs/advanced_installation.md
+++ b/docs/advanced_installation.md
@@ -1,18 +1,12 @@
 # Advanced Installation
 
-This installation is for advanced users that want to contribute to the project
-and/or add new resources or modify existing resources.
+This installation is for advanced users that want to contribute to the project and/or add new resources or modify existing resources.
 
-If you want to contribute only to the operator's code or otherwise don't have to
-do any substantial resource modification, then please follow
-[Basic Installation](./basic_installation.md).
+If you want to contribute only to the operator's code or otherwise don't have to do any substantial resource modification, then please follow [Basic Installation](./basic_installation.md).
 
-This will require some additional dependencies and a knowledge of
-[Kustomize](https://kubernetes-sigs.github.io/kustomize/guides/).
+This will require some additional dependencies and a knowledge of [Kustomize](https://kubernetes-sigs.github.io/kustomize/guides/).
 
-If you do want to contribute, please follow
-[Contributing](../README.MD#contributing) and our
-[Code of Conduct](../code-of-conduct.md) before doing so.
+If you do want to contribute, please follow [Contributing](../README.MD#contributing) and our [Code of Conduct](../code-of-conduct.md) before doing so.
 
 ## Requirements
 
@@ -20,21 +14,16 @@ If you do want to contribute, please follow
 
 You need to have the following:
 
-* access to a Kubernetes cluster running at least version `1.11.3` and
-[kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-properly set up
-* a Project in [Google Cloud](https://console.cloud.google.com/) with
-[Service Directory](https://cloud.google.com/service-directory) enabled
-* a [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts)
-with at least role `roles/servicedirectory.editor`.
+* access to a Kubernetes cluster running at least version `1.11.3` and [kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) properly set up
+* a Project in [Google Cloud](https://console.cloud.google.com/) with [Service Directory](https://cloud.google.com/service-directory) enabled
+* a [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts) with at least role `roles/servicedirectory.editor`.
 
 ### Software
 
 Please make sure you have the following software installed:
 
 * [Kubectl 1.11.3+](https://kubernetes.io/docs/tasks/tools/install-kubectl/):
-  * *Unix/Linux* users with
-  [Snap](https://snapcraft.io/docs/installing-snapd):
+  * *Unix/Linux* users with [Snap](https://snapcraft.io/docs/installing-snapd):
 
     ```bash
     snap install kubectl --classic
@@ -46,28 +35,20 @@ Please make sure you have the following software installed:
     brew install kubectl
     ```
 
-  * *Windows* users: follow
-  [this section](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-windows)
-  of the documentation
+  * *Windows* users: follow [this section](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-windows) of the documentation
 * [Make](https://www.gnu.org/software/make/), which will automate some steps:
   * *Unix/Linux and MacOS*: already pre-installed.
-  * *Windows* users: download the binaries from
-  [this page](http://gnuwin32.sourceforge.net/packages/make.htm).
-* [Golang 1.13+](https://golang.org/doc/install) to build the project. Follow
-the link to learn how to install it for any system.
-* [Docker 17.03+](https://www.docker.com/get-started) for building and pushing
-the operator's container images.
-  * *Unix/Linux* users with
-  [Snap](https://snapcraft.io/docs/installing-snapd):
+  * *Windows* users: download the binaries from [this page](http://gnuwin32.sourceforge.net/packages/make.htm).
+* [Golang 1.13+](https://golang.org/doc/install) to build the project. Follow the link to learn how to install it for any system.
+* [Docker 17.03+](https://www.docker.com/get-started) for building and pushing the operator's container images.
+  * *Unix/Linux* users with [Snap](https://snapcraft.io/docs/installing-snapd):
 
   ```bash
   sudo snap install docker
   ```
 
-  * *MacOs* users:
-  [Docker Desktop for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
-  * *Windows* users:
-  [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows/)
+  * *MacOs* users: [Docker Desktop for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+  * *Windows* users: [Docker Desktop for Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows/)
 
 * [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#installation):
   * *MacOs* users with [HomeBrew](https://brew.sh/):
@@ -76,42 +57,25 @@ the operator's container images.
   brew install kubebuilder
   ```
 
-  * *Other systems*: follow
-  [this section](https://book.kubebuilder.io/quick-start.html#installation)
-  on the documentation.
+  * *Other systems*: follow [this section](https://book.kubebuilder.io/quick-start.html#installation) on the documentation.
 
 ### Optional: New YAML files
 
-If you are not adding any new Kubernetes resources, such as `Secret`s,
-`Deployment`s, `Service`s, etc., you can skip this section and go directly
-to [Configure the operator](#configure-the-operator).
+If you are not adding any new Kubernetes resources, such as `Secret`s, `Deployment`s, `Service`s, etc., you can skip this section and go directly to [Configure the operator](#configure-the-operator).
 
-Note that this is different from `CRD`s, as the CN-WAN Operator does not have
-any custom resources.
+Note that this is different from `CRD`s, as the CN-WAN Operator does not have any custom resources.
 
-As a reminder, if you are adding resources to CN-WAN
-Operator to contribute to the project, please discuss the changes you want
-to make with the CN-WAN Operator [OWNERS](../OWNERS.md) by opening a new
-[issue](https://github.com/CloudNativeSDWAN/cnwan-operator/issues)
-or by email prior to make a pull request.
+As a reminder, if you are adding resources to CN-WAN Operator to contribute to the project, please discuss the changes you want to make with the CN-WAN Operator [OWNERS](../OWNERS.md) by opening a new [issue](https://github.com/CloudNativeSDWAN/cnwan-operator/issues) or by email prior to make a pull request.
 
-Finally, if you just want to do simple modifications, like set a docker pull
-secret, you should modify files inside `deploy` and follow
-[Basic Installation](./basic_installation.md).
+Finally, if you just want to do simple modifications, like set a docker pull secret, you should modify files inside `deploy` and follow [Basic Installation](./basic_installation.md).
 
 #### Directories organization
 
-You will have to put the `YAML` files in one of the sub-directories of
-`/config`: if you are modifying/adding resources just for your own sake,
-then you can place them in whichever folder you want, so long as you also
-modify `kustomazion.yaml` accordingly, as specified below.
+You will have to put the `YAML` files in one of the sub-directories of `/config`: if you are modifying/adding resources just for your own sake, then you can place them in whichever folder you want, so long as you also modify `kustomazion.yaml` accordingly, as specified below.
 
-Instead, in case you are adding files for the project, we ask you to place
-files depending on the `Kind` of such resources: i.e. `Role`s in `rbac`,
-`WebHook`s in `webhook` and everything else in `manager`.
+Instead, in case you are adding files for the project, we ask you to place files depending on the `Kind` of such resources: i.e. `Role`s in `rbac`, `WebHook`s in `webhook` and everything else in `manager`.
 
-Modify the `kustomization.yaml` file by adding the file you just placed. For
-example, take a look at `config/manager/kustomization.yaml`:
+Modify the `kustomization.yaml` file by adding the file you just placed. For example, take a look at `config/manager/kustomization.yaml`:
 
 ```yaml
 resources:
@@ -122,14 +86,9 @@ patchesStrategicMerge:
 - patch.yaml
 ```
 
-If you are adding a new `Service`, add its file name without path under
-`resources:` the same way you see above.  
-Specify any modification you want to do on resources, by adding your patch
-under `patchesStrategicMerge:`.
+If you are adding a new `Service`, add its file name without path under `resources:` the same way you see above. Specify any modification you want to do on resources, by adding your patch under `patchesStrategicMerge:`.
 
-Please take a look at
-[this guide](https://kubernetes-sigs.github.io/kustomize/guides/)
-to learn how to use Kustomize in case this looks too obscure.
+Please take a look at [this guide](https://kubernetes-sigs.github.io/kustomize/guides/) to learn how to use Kustomize in case this looks too obscure.
 
 ## Configure the operator
 
@@ -138,14 +97,11 @@ Before deploying the operator you will need to configure it.
 ### Settings
 
 Modify the file `config/manager/settings.yaml` with the appropriate values.  
-You will need to modify what's below `settings.yaml: |` and follow
-[Configuration](./configuration.md) if you haven't already.
+You will need to modify what's below `settings.yaml: |` and follow [Configuration](./configuration.md) if you haven't already.
 
 ### Credentials
 
-Copy the contents of you Service Account and paste to
-`config/manager/serviceHandlerSecret.yaml` below
-`gcloud-credentials.json: |-`.
+Copy the contents of you Service Account and paste to `config/manager/serviceHandlerSecret.yaml` below `gcloud-credentials.json: |-`.
 
 The file must look like this:
 
@@ -171,26 +127,17 @@ stringData:
     }
 ```
 
-Please **double-check indentation**: if invalid, it will violate yaml parsing
-rules and treated as an empty string. Make sure it is as above.
+Please **double-check indentation**: if invalid, it will violate yaml parsing rules and treated as an empty string. Make sure it is as above.
 
 ## Build the Operator
 
-First, you need to build and push the docker image to your container registry
-of choice. To ease the process up, you can edit the `Makefile` - included in
-the root folder of the project - by entering the image repository where
-you want to push the image:
+First, you need to build and push the docker image to your container registry of choice. To ease the process up, you can edit the `Makefile` - included in the root folder of the project - by entering the image repository where you want to push the image:
 
 ```makefile
 IMG ?= example.com/username/image:tag
 ```
 
-Make sure you are properly logged in your container registry of choice before
-proceeding. Most of the times, running `docker login <registry>` as documented
-[here](https://docs.docker.com/engine/reference/commandline/login/) should be
-enough, but we encourage you to read your container registry's official
-documentation to know how to do that.  
-Build and push the image:
+Make sure you are properly logged in your container registry of choice before proceeding. Most of the times, running `docker login <registry>` as documented [here](https://docs.docker.com/engine/reference/commandline/login/) should be enough, but we encourage you to read your container registry's official documentation to know how to do that. Build and push the image:
 
 ```bash
 # Build & Push
@@ -199,18 +146,15 @@ make docker-build docker-push
 
 ## Deploy
 
-Deploy the operator on your cluster by running the command below from the root
-directory of the project:
+Deploy the operator on your cluster by running the command below from the root directory of the project:
 
 ```bash
 make custom-deploy
 ```
 
-The operator will be first tested and, if successful, installed in one of the
-available and suitable worker nodes of your cluster.
+The operator will be first tested and, if successful, installed in one of the available and suitable worker nodes of your cluster.
 
-If you haven't already, please read [Concepts](./concepts.md) to learn more
-about CN-WAN Operator.
+If you haven't already, please read [Concepts](./concepts.md) to learn more about CN-WAN Operator.
 
 ## Remove
 

--- a/docs/basic_installation.md
+++ b/docs/basic_installation.md
@@ -2,8 +2,7 @@
 
 This is the easiest way to install the operator and suitable for most users.
 
-This will install/deploy the latest released version of the operator without
-modifying any YAML resource from this repository.
+This will install/deploy the latest released version of the operator without modifying any YAML resource from this repository.
 
 ## Requirements
 
@@ -11,21 +10,16 @@ modifying any YAML resource from this repository.
 
 You need to have the following:
 
-* access to a Kubernetes cluster running at least version `1.11.3` and
-[kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-properly set up
-* a Project in [Google Cloud](https://console.cloud.google.com/) with
-[Service Directory](https://cloud.google.com/service-directory) enabled
-* a [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts)
-with at least role `roles/servicedirectory.editor`.
+* access to a Kubernetes cluster running at least version `1.11.3` and [kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) properly set up
+* a Project in [Google Cloud](https://console.cloud.google.com/) with [Service Directory](https://cloud.google.com/service-directory) enabled
+* a [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts) with at least role `roles/servicedirectory.editor`.
 
 ### Software
 
 Please make sure you have the following software installed:
 
 * [Kubectl 1.11.3+](https://kubernetes.io/docs/tasks/tools/install-kubectl/):
-  * *Unix/Linux* users with
-  [Snap](https://snapcraft.io/docs/installing-snapd):
+  * *Unix/Linux* users with [Snap](https://snapcraft.io/docs/installing-snapd):
 
     ```bash
     snap install kubectl --classic
@@ -37,16 +31,11 @@ Please make sure you have the following software installed:
     brew install kubectl
     ```
 
-  * *Windows* users: follow
-  [this section](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-windows)
-  of the documentation
+  * *Windows* users: follow [this section](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-on-windows) of the documentation
 
 ### Simple Modifications
 
-If you need to do some simple modifications, such as change the docker image or
-set a docker pull secret, you can do so by modifying the files in `/deploy`.  
-But if you need to do more advanced modifications, then you will have to follow
-[Advanced Installation](./advanced_installation.md).
+If you need to do some simple modifications, such as change the docker image or set a docker pull secret, you can do so by modifying the files in `/deploy`. But if you need to do more advanced modifications, then you will have to follow [Advanced Installation](./advanced_installation.md).
 
 ## Configure the operator
 
@@ -55,20 +44,15 @@ Before deploying the operator you will need to configure it.
 ### Settings
 
 Modify the file `deploy/settings/settings.yaml` with the appropriate values.  
-If you haven't already, please read [Configuration](./configuration.md) to
-learn how to do this.
+If you haven't already, please read [Configuration](./configuration.md) to learn how to do this.
 
 ### Credentials
 
-Place your Google account in `deploy/settings` and rename it as
-`gcloud-credentials.json`.  
-Therefore, your `deploy/settings` will contain `settings.yaml` and
-`gcloud-credentials.json`.
+Place your Google account in `deploy/settings` and rename it as `gcloud-credentials.json`. Therefore, your `deploy/settings` will contain `settings.yaml` and `gcloud-credentials.json`.
 
 ## Deploy
 
-While you can deploy the operator with plain kubectl commands, CN-WAN Operator
-comes with scripts that automate such commands for you.
+While you can deploy the operator with plain kubectl commands, CN-WAN Operator comes with scripts that automate such commands for you.
 
 From the root directory of the project, execute
 
@@ -80,11 +64,9 @@ From the root directory of the project, execute
 ./scripts/deploy.sh example.com/repository/image:tag
 ```
 
-If everything goes fine, CN-WAN Operator will run in namespace
-`cnwan-operator-system` and deployed to a suitable and available worker node.
+If everything goes fine, CN-WAN Operator will run in namespace `cnwan-operator-system` and deployed to a suitable and available worker node.
 
-If you haven't already, please read [Concepts](./concepts.md) to learn more
-about CN-WAN Operator.
+If you haven't already, please read [Concepts](./concepts.md) to learn more about CN-WAN Operator.
 
 ## Remove
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -15,94 +15,55 @@
 
 ## How it Works
 
-CN-WAN Operator implements the
-[operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/):
-it is a standalone program that runs in the Kubernetes cluster and extends it
-by offering additional functionalities.
+CN-WAN Operator implements the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/): it is a standalone program that runs in the Kubernetes cluster and extends it by offering additional functionalities.
 
-Specifically, it watches for changes in
-[Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
-and whenever a change is detected, the operator extracts some data out of the
-service, i.e. endpoints and annotations, and connects to a
-[Service Registry](https://auth0.com/blog/an-introduction-to-microservices-part-3-the-service-registry/)
-to reflect such changes to it. Example of such changes include new services
-deployed, updates to a service's annotations list and deleted services.
+Specifically, it watches for changes in [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) and whenever a change is detected, the operator extracts some data out of the service, i.e. endpoints and annotations, and connects to a [Service Registry](https://auth0.com/blog/an-introduction-to-microservices-part-3-the-service-registry/) to reflect such changes to it. Example of such changes include new services deployed, updates to a service's annotations list and deleted services.
 
 ## Supported Service Types
 
-Currently, only services of type `LoadBalancer` are supported, and all other
-types are ignored by the operator.
+Currently, only services of type `LoadBalancer` are supported, and all other types are ignored by the operator.
 
-Please make sure your cluster supports load balancers before deploying the
-operator: most managed Kubernetes platforms do support them, but in case
-you are not running a managed Kubernetes you may use
-[MetalLB](https://metallb.universe.tf/) or explore other load balancer
-solutions.
+Please make sure your cluster supports load balancers before deploying the operator: most managed Kubernetes platforms do support them, but in case you are not running a managed Kubernetes you may use [MetalLB](https://metallb.universe.tf/) or explore other load balancer solutions.
 
 ## Service Registry
 
-A service registry is basically a database of services: each registered service
-provides information about its instances, addresses, ports and other data.
-Often times, *metadata* can be registered as well, which provide additional data
-about the service.
+A service registry is basically a database of services: each registered service provides information about its instances, addresses, ports and other data. Often times, *metadata* can be registered as well, which provide additional data about the service.
 
-Therefore, a client can log in to the service registry and *discover*
-registered services to know how to connect to them and get data about them.
-Sounds familiar? That's because it is very similar to how DNS works, but the
-service registry pattern is a
-[key concept of microservices](https://auth0.com/blog/an-introduction-to-microservices-part-3-the-service-registry/).
+Therefore, a client can log in to the service registry and *discover* registered services to know how to connect to them and get data about them. Sounds familiar? That's because it is very similar to how DNS works, but the service registry pattern is a [key concept of microservices](https://auth0.com/blog/an-introduction-to-microservices-part-3-the-service-registry/).
 
 ## Metadata
 
-When the CN-WAN Operator registers/modifies a service in the service registry,
-it will also register some metadata with it, if the service registry allows
-it.  
-Think of metadata as a collection of `key: value` pairs that provide more
-information about the service.  
-For example, you may want to label a service with metadata `version: 2.1`.
+When the CN-WAN Operator registers/modifies a service in the service registry, it will also register some metadata with it, if the service registry allows it. Think of metadata as a collection of `key: value` pairs that provide more information about the service. For example, you may want to label a service with metadata `version: 2.1`.
 
-You can define the metadata you wish to be registered in a service by
-**annotating** the corresponding Kubernetes Service. For example:
+You can define the metadata you wish to be registered in a service by **annotating** the corresponding Kubernetes Service. For example:
 
 ```bash
 kubectl annotate service my-service version=2.1
 ```
 
-The operator will see this annotation and,
-[if you enable it](#allowed-annotations),
-it will be kept and inserted among the service's metadata when it is published
-in the service registry.
+The operator will see this annotation and, [if you enable it](#allowed-annotations), it will be kept and inserted among the service's metadata when it is published in the service registry.
 
 ## Annotations vs Labels
 
-Let's further elaborate the *Metadata* section and specify why we treat
-*annotations* as metadata instead of doing that with *labels*.
+Let's further elaborate the *Metadata* section and specify why we treat *annotations* as metadata instead of doing that with *labels*.
 
-The CN-WAN Operator reads *annotations* and not *labels* because they are the
-closest to metadata: let's take a look at how Kubernetes defines
-[annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
-and [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/):
+The CN-WAN Operator reads *annotations* and not *labels* because they are the closest to metadata: let's take a look at how Kubernetes defines [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/):
 
-> **Labels** can be used to select objects and to find collections of objects
-> that satisfy certain conditions.
+> **Labels** can be used to select objects and to find collections of objects that satisfy certain conditions.
 >
 > In contrast, **annotations** are not used to identify and select objects.
 >
-> **Labels** are intended to be used to specify identifying attributes of
-> objects that are meaningful and relevant to users.
+> **Labels** are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users.
 >
 > Non-identifying information should be recorded using **annotations**.
 
 And, one use case for what you can store in annotations:
 
-> Build, release, or image information like timestamps, release IDs, git
-> branch, PR numbers, image hashes, and registry address.
+> Build, release, or image information like timestamps, release IDs, git branch, PR numbers, image hashes, and registry address.
 
 Which is something you may want to reflect in a service registry.
 
-So, to summarize, *annotations* are used to store more information about that
-resource and therefore is the closest concept to metadata, while *labels* are
-used to identify resources.
+So, to summarize, *annotations* are used to store more information about that resource and therefore is the closest concept to metadata, while *labels* are used to identify resources.
 
 You can quickly annotate a resource, i.e. a service, like this:
 
@@ -118,31 +79,15 @@ kubectl annotate service service-name image-name-
 
 ## Ownership
 
-Whenever the CN-WAN Operator **creates** a resource - *any resource*, including
-namespaces, services and endpoints, on the service registry, it automatically
-inserts the reserved metadata `owner: cnwan-operator`.
-This will make the operator skip all those resources that have been created by
-someone else, i.e. manually by you or a program created by another entity:
-this will prevent us from messing up pre-existing configuration.
+Whenever the CN-WAN Operator **creates** a resource - *any resource*, including namespaces, services and endpoints, on the service registry, it automatically inserts the reserved metadata `owner: cnwan-operator`. This will make the operator skip all those resources that have been created by someone else, i.e. manually by you or a program created by another entity: this will prevent us from messing up pre-existing configuration.
 
-That being said, the operator will still insert child resources even if the
-parent resource is not owned by the operator.  
-For example: if your service registry contains a service called `my-service`
-that does **not** have the `owner: cnwan-operator` metadata or that has
-something else entirely - i.e. `owner: someone-else`, then the operator will
-never update or delete its metadata, but will still add endpoints under it,
-as long as they, again, do not already exist and are owned by someone else.
+That being said, the operator will still insert child resources even if the parent resource is not owned by the operator. For example: if your service registry contains a service called `my-service` that does **not** have the `owner: cnwan-operator` metadata or that has something else entirely - i.e. `owner: someone-else`, then the operator will never update or delete its metadata, but will still add endpoints under it, as long as they, again, do not already exist and are owned by someone else.
 
-Finally, if you wish the operator to manage your pre-existing resources on your
-service registry, please update all the necessary resources by inserting
-`owner: cnwan-operator` among their metadata.
+Finally, if you wish the operator to manage your pre-existing resources on your service registry, please update all the necessary resources by inserting `owner: cnwan-operator` among their metadata.
 
 ## Namespace Lists
 
-For the CN-WAN Operator, a namespace can belong to two lists: *allowlist* or
-*blocklist*.  
-CN-WAN Operator only processes services that belong to namespaces it is allowed
-to work on: those that are inside the *allowlist*.
+For the CN-WAN Operator, a namespace can belong to two lists: *allowlist* or *blocklist*. CN-WAN Operator only processes services that belong to namespaces it is allowed to work on: those that are inside the *allowlist*.
 
 To insert a namespace in a list, you have to label it like this:
 
@@ -154,9 +99,7 @@ kubectl label ns namespace-name operator.cnwan.io/allowed=yes
 kubectl label ns namespace-name operator.cnwan.io/blocked=yes
 ```
 
-It doesn't really matter what you put as value (in this case `yes` has
-been inserted), just as long as the key `operator.cnwan.io/<key>` is as
-specified above.
+It doesn't really matter what you put as value (in this case `yes` has been inserted), just as long as the key `operator.cnwan.io/<key>` is as specified above.
 
 Similarly, to remove a namespace from the list:
 
@@ -168,56 +111,33 @@ kubectl label ns namespace-name operator.cnwan.io/allowed-
 kubectl label ns namespace-name operator.cnwan.io/blocked-
 ```
 
-To prevent you from manually inserting a namespace in a list each time,
-you can define the [Default Namespace List Policy](#namespace-list-policy).
+To prevent you from manually inserting a namespace in a list each time, you can define the [Default Namespace List Policy](#namespace-list-policy).
 
 ## Namespace List Policy
 
-As we said, the operator watches for changes in Kubernetes services. While
-it does watch all services, it does **not** process services that belong to
-namespaces that the operator is not allowed to work on.
+As we said, the operator watches for changes in Kubernetes services. While it does watch all services, it does **not** process services that belong to namespaces that the operator is not allowed to work on.
 
-To prevent you from manually allowing/blocking namespaces each time, the
-operator defines a *default namespace list policy*.
+To prevent you from manually allowing/blocking namespaces each time, the operator defines a *default namespace list policy*.
 
-Setting this default policy as `allowlist` means that, by default, all
-namespaces are **blocked** and the operator will work only on the ones
-you have specifically allowed.  
-This is useful when you want few namespaces to be allowed or when you want
-to retain full control over which ones are allowed.  
+Setting this default policy as `allowlist` means that, by default, all namespaces are **blocked** and the operator will work only on the ones you have specifically allowed. This is useful when you want few namespaces to be allowed or when you want to retain full control over which ones are allowed.
 
-In contrast, if you have a lot of namespaces that you want to enable, or you
-want the operator to work more "automatically", or you virtually
-want to enable all namespaces, than you can set the default policy as
-`blocklist` which means that, by default, all namespaces are **allowed** and
-you will have to specify only the ones that must be blocked.
+In contrast, if you have a lot of namespaces that you want to enable, or you want the operator to work more "automatically", or you virtually want to enable all namespaces, than you can set the default policy as `blocklist` which means that, by default, all namespaces are **allowed** and you will have to specify only the ones that must be blocked.
 
-Refer to the previous section to know how to insert a namespace into a certain
-list.
+Refer to the previous section to know how to insert a namespace into a certain list.
 
-Please follow [this guide](./configuration.md#set-the-namespace-list-policy)
-to learn how to set up the default namespace list policy.
+Please follow [this guide](./configuration.md#set-the-namespace-list-policy) to learn how to set up the default namespace list policy.
 
 ## Allowed Annotations
 
-As we said in [Metadata](#metadata), *annotations* are treated as metadata.
-To avoid publishing potentially sensitive data to the service registry, you can
-fine tune which annotations will be allowed and which will have to be ignored.
+As we said in [Metadata](#metadata), *annotations* are treated as metadata. To avoid publishing potentially sensitive data to the service registry, you can fine tune which annotations will be allowed and which will have to be ignored.
 
-If a service does not have **at least** one of the allowed annotations, then
-it will be ignored by the operator or be removed from the service registry, if
-present.
+If a service does not have **at least** one of the allowed annotations, then it will be ignored by the operator or be removed from the service registry, if present.
 
-You can define which annotations are allowed by setting up
-[configurations](./configuration.md#allow-annotations).
+You can define which annotations are allowed by setting up [configurations](./configuration.md#allow-annotations).
 
 ## Deploy
 
-There are two ways to deploy the operator, according to your use case and
-knowledge of Kubernetes:
+There are two ways to deploy the operator, according to your use case and knowledge of Kubernetes:
 
-* If you want to use the operator "as-is", i.e. you don't want to change
-its code and/or resources, you can follow
-[Basic Installation](./basic_installation.md).
-* If you want to modify resources, i.e. add new ones or update existing ones,
-you can follow [Advanced Installation](./advanced_installation.md).
+* If you want to use the operator "as-is", i.e. you don't want to change its code and/or resources, you can follow [Basic Installation](./basic_installation.md).
+* If you want to modify resources, i.e. add new ones or update existing ones, you can follow [Advanced Installation](./advanced_installation.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,6 @@
 # Configure the Operator
 
-This section will guide you through the steps you need to take to configure
-the CN-WAN Operator.
+This section will guide you through the steps you need to take to configure the CN-WAN Operator.
 
 ## Table of Contents
 
@@ -29,9 +28,7 @@ service:
 
 ## Google Cloud Settings
 
-Under `gcloud` you can specify Google Cloud data. For example, you can specify
-the project and the region where Service Directory is enabled and you want to
-be managed.
+Under `gcloud` you can specify Google Cloud data. For example, you can specify the project and the region where Service Directory is enabled and you want to be managed.
 
 You can modify `region` and `project` with the appropriate values.
 
@@ -46,15 +43,11 @@ gcloud:
 
 ## Set the Namespace List Policy
 
-The operator will only monitor services that belong to a namespace that you
-have explicitly allowed.
+The operator will only monitor services that belong to a namespace that you have explicitly allowed.
 
-if you haven't already, please take a look at
-[this section](./concepts.md#namespace-list-policy) to learn more about
-the *default namespace list policy*.
+if you haven't already, please take a look at [this section](./concepts.md#namespace-list-policy) to learn more about the *default namespace list policy*.
 
-To set the list policy, change `listPolicy` value to either `allowlist`
-or `blocklist` like so:
+To set the list policy, change `listPolicy` value to either `allowlist` or `blocklist` like so:
 
 ```yaml
 namespace:
@@ -63,16 +56,11 @@ namespace:
 
 ## Allow Annotations
 
-The operator will not register every annotation as metadata from a Kubernetes
-Service, but will only do so with the ones you have explicitly allowed.
+The operator will not register every annotation as metadata from a Kubernetes Service, but will only do so with the ones you have explicitly allowed.
 
-if you haven't already, please take a look at
-[Metadata](./concepts.md#metadata),
-[Allowed Annotations](./concepts.md#allowed-annotations) and
-[Annotations vs Labels](./concepts.md#annotations-vs-labels) to learn more.
+if you haven't already, please take a look at [Metadata](./concepts.md#metadata), [Allowed Annotations](./concepts.md#allowed-annotations) and [Annotations vs Labels](./concepts.md#annotations-vs-labels) to learn more.
 
-You can allow annotations by setting up `service.annotations` in the
-configuration. For example:
+You can allow annotations by setting up `service.annotations` in the configuration. For example:
 
 ```yaml
 service:
@@ -84,17 +72,9 @@ service:
 Values can also have wildcards. Example of accepted values are:
 
 * Specific values, i.e. `example.prefix.com/name` or `annotation-key`
-* Name wildcards, i.e. `example.prefix.com/*`: *all* annotations that have
-prefix `example.prefix.com` will be kept and registered, regardless of the
-name. For instance, `example.prefix.com/my-name` and
-`example.prefix.com/another-name` will both match and therefore be included in
-the service's entry as metadata, along with their values.
-* Prefix wildcards, i.e. `*/name`, *all* annotations that have name `name`
-will be stored and registered, regardless of the prefix.
-`example.prefix.com/name` and `another.prefix.com/name` will both match.
-* `*/*`: *all* annotations will be registered. We discourage you from using
-this value, as you may potentially expose sensitive information about the
-service.
+* Name wildcards, i.e. `example.prefix.com/*`: *all* annotations that have prefix `example.prefix.com` will be kept and registered, regardless of the name. For instance, `example.prefix.com/my-name` and `example.prefix.com/another-name` will both match and therefore be included in the service's entry as metadata, along with their values.
+* Prefix wildcards, i.e. `*/name`, *all* annotations that have name `name` will be stored and registered, regardless of the prefix. `example.prefix.com/name` and `another.prefix.com/name` will both match.
+* `*/*`: *all* annotations will be registered. We discourage you from using this value, as you may potentially expose sensitive information about the service.
 
 For instance, take a look at this service's annotations:
 
@@ -123,14 +103,11 @@ my.prefix.com/another-name: another-value
 name-with-no-prefix: simple-value
 ```
 
-Finally, if you leave this empty - as `annotations: []`, then no service will
-match this and, therefore, no service will be registered.
+Finally, if you leave this empty - as `annotations: []`, then no service will match this and, therefore, no service will be registered.
 
 ## Deploy
 
-To deploy these settings you will have to follow either
-[Basic Installation](./basic_installation.md) or
-[Advanced Installation](./advanced_installation.md).
+To deploy these settings you will have to follow either [Basic Installation](./basic_installation.md) or [Advanced Installation](./advanced_installation.md).
 
 ## Update
 
@@ -140,19 +117,16 @@ To update the settings, you can run
 kubectl edit configmap cnwan-operator-settings -n cnwan-operator-system
 ```
 
-This will open your default editor and you will be able to edit the settings
-inline.
+This will open your default editor and you will be able to edit the settings inline.
 
-If successful, you will have to restart the operator for it to be able to
-acknowledge the changes:
+If successful, you will have to restart the operator for it to be able to acknowledge the changes:
 
 ```bash
 # For Kubernetes 1.15+
 kubectl rollout restart deployment cnwan-operator-controller-manager -n cnwan-operator-system
 ```
 
-In case your Kubernetes version is lower, than you will have to either delete
-the pod or scale down the deployment:
+In case your Kubernetes version is lower, than you will have to either delete the pod or scale down the deployment:
 
 ```bash
 NAME=$(kubectl get pods -o jsonpath='{.items[0].metadata.name}' -n cnwan-operator-system)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,28 +1,22 @@
 # Quickstart
 
-Curious to see CN-WAN Operator in action but feeling lazy about learning
-how it does stuff? Follow this guide!
+Curious to see CN-WAN Operator in action but feeling lazy about learning how it does stuff? Follow this guide!
 
 ## Requirements
 
 To run this, make sure you have:
 
 * Access to a Kubernetes cluster running at least version `1.11.3`
-  * [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/)
-  is also fine.
+  * [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) is also fine.
 * [Kubectl 1.11.3+](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* A Project in [Google Cloud](https://console.cloud.google.com/) with
-[Service Directory](https://cloud.google.com/service-directory) enabled
-* A [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts)
-with at least role `roles/servicedirectory.editor`.
+* A Project in [Google Cloud](https://console.cloud.google.com/) with [Service Directory](https://cloud.google.com/service-directory) enabled
+* A [Google Cloud Service Account](https://cloud.google.com/iam/docs/service-accounts) with at least role `roles/servicedirectory.editor`.
 
 Additionally:
 
-* [kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
-properly set up.
+* [kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) properly set up.
 * Your cluster is able to perform outbound HTTP/S requests successfully.
-* Your cluster supports [LoadBalancer](./concepts.md#supported-service-types)
-type of services.
+* Your cluster supports [LoadBalancer](./concepts.md#supported-service-types) type of services.
 
 ## Let's go
 
@@ -35,8 +29,7 @@ cd ./cnwan-operator
 
 ### 2 - Deploy a test service
 
-We will suppose you are deploying an application on your cluster where
-your employees can log in and watch training videos.
+We will suppose you are deploying an application on your cluster where your employees can log in and watch training videos.
 
 Run this to deploy a new namespace and a service in that namespace:
 
@@ -72,11 +65,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label:
-`operator.cnwan.io/allowed: yes` which inserts the namespace in the opeartor's
-[allowlist](./concepts.md#namespace-lists).  
-Also notice that the service has annotations that will be registered as
-[metadata](./concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/allowed: yes` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -101,25 +90,17 @@ NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)   
 web-training           LoadBalancer   10.11.12.13      20.21.22.23    80:32058/TCP                  1h
 ```
 
-If you see `<none>` or `<pending>` under `EXTERNAL-IP` you either have to wait
-to see an IP there or your cluster doesn't support
-[LoadBalancer](./concepts.md#supported-service-types).
+If you see `<none>` or `<pending>` under `EXTERNAL-IP` you either have to wait to see an IP there or your cluster doesn't support [LoadBalancer](./concepts.md#supported-service-types).
 
-It doesn't really matter that there is no pod backing this service for now, as
-this is just a test. Of course, in a real world scenario you should make sure
-a pod is there.
+It doesn't really matter that there is no pod backing this service for now, as this is just a test. Of course, in a real world scenario you should make sure a pod is there.
 
 ### 3 - Provide the service account
 
-Navigate to the root directory and place your service account to
-`deploy/settings`, with name `gcloud-credentials.json`.  
-So, you will have `deploy/settings/gcloud-credentials.json`.
+Navigate to the root directory and place your service account to `deploy/settings`, with name `gcloud-credentials.json`. So, you will have `deploy/settings/gcloud-credentials.json`.
 
 ### 4 - Provide settings
 
-From the root directory navigate to `deploy/settings` and modify the file
-`settings.yaml` to look like this - please provide appropriate values in place
-of `<gcloud-project>` and `<gcloud-region>`:
+From the root directory navigate to `deploy/settings` and modify the file `settings.yaml` to look like this - please provide appropriate values in place of `<gcloud-project>` and `<gcloud-region>`:
 
 ```yaml
 gcloud:
@@ -142,8 +123,7 @@ Please notice the values inside `annotations`:
   - version
 ```
 
-This means that the operator will register `traffic-profile` as metadata if it finds it among a
-[service's annotations list](./concepts.md#allowed-annotations).
+This means that the operator will register `traffic-profile` as metadata if it finds it among a [service's annotations list](./concepts.md#allowed-annotations).
 
 ### 4 - Deploy the operator
 
@@ -155,22 +135,15 @@ From the root directory of the project, execute
 
 ### 5 - See it on Service Directory
 
-Now, log in to Service Directory from the google cloud console and you will
-see a namespace that has the same name as the Kubernetes namespace where that
-service was found in.
+Now, log in to Service Directory from the google cloud console and you will see a namespace that has the same name as the Kubernetes namespace where that service was found in.
 
-If you click on it, you will see a service: its metadata
-contain `traffic-profile: standard`. It will also contain an endpoint with data
-about the port and the address.
+If you click on it, you will see a service: its metadata contain `traffic-profile: standard`. It will also contain an endpoint with data about the port and the address.
 
 ### 6 - Update metadata
 
-Now you're basically done, but you can follow these additional steps to see
-more of the operator in action.
+Now you're basically done, but you can follow these additional steps to see more of the operator in action.
 
-Suppose you made a mistake: this is a training application where your employees
-will follow video tutorials. Therefore, its kind of traffic - or, *profile*,
-must be `video`.
+Suppose you made a mistake: this is a training application where your employees will follow video tutorials. Therefore, its kind of traffic - or, *profile*, must be `video`.
 
 Execute:
 
@@ -182,27 +155,19 @@ The operator has updated the metadata in Service Directory accordingly.
 
 ### 7 - Add new metadata
 
-Suppose you have a CI/CD pipeline that for each PR builds a container with a
-new tag. Also, it updates the service that serves the pods running that
-container by specifying the new version.  
-Today, you will be that pipeline:
+Suppose you have a CI/CD pipeline that for each PR builds a container with a new tag. Also, it updates the service that serves the pods running that container by specifying the new version. Today, you will be that pipeline:
 
 ```bash
 kubectl annotate service web-training version=2.2 -n training-app-namespace
 ```
 
-Once again, log in to Service Directory and see how the metadata for that
-service have changed accordingly.
+Once again, log in to Service Directory and see how the metadata for that service have changed accordingly.
 
 ## Where to go from here
 
-Well, that's it for a quickstart. Now we encourage you to learn more about
-CN-WAN Operator by taking a look at the [docs](./docs).
+Well, that's it for a quickstart. Now we encourage you to learn more about CN-WAN Operator by taking a look at the [docs](./docs).
 
-Also, make sure you read the
-[official documentation of CN-WAN](https://github.com/CloudNativeSDWAN/cnwan-docs)
-to learn how you can apply this simple quickstart to a real world
-scenario.
+Also, make sure you read the [official documentation of CN-WAN](https://github.com/CloudNativeSDWAN/cnwan-docs) to learn how you can apply this simple quickstart to a real world scenario.
 
 ## Clean up
 


### PR DESCRIPTION
Some Markdown rendering engines add line breaks to the generated HTML,
so in order to have nicely formatted docs, remove the line breaks.

Signed-off-by: Lori Jakab <lojakab@cisco.com>