### PR TITLE
Fix broken install-kubebuilder workflow step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,12 @@ jobs:
 
       - name: install kubebuilder
         id: install-kubebuilder
-        uses: RyanSiu1995/kubebuilder-action@v1
-        with:
-          version: 2.3.1
-
+        run: |
+            os=$(go env GOOS)
+            arch=$(go env GOARCH)
+            curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+            sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+            export PATH=$PATH:/usr/local/kubebuilder/bin
       - id: test-code
         name: test
         run: make test


### PR DESCRIPTION
This commit fixes step `install-kubebuilder`. Tests should work fine again.