### PR TITLE
Improve namespace filtering

### DIFF
--- a/artifacts/settings/settings.yaml
+++ b/artifacts/settings/settings.yaml
@@ -1,6 +1,5 @@
 enableNamespaceByDefault: false
-service:
-  annotations: []
+serviceAnnotations: []
 serviceRegistry:
   etcd:
     prefix: <prefix>

--- a/artifacts/settings/settings.yaml
+++ b/artifacts/settings/settings.yaml
@@ -1,5 +1,4 @@
-namespace:
-  listPolicy: allowlist
+enableNamespaceByDefault: false
 service:
   annotations: []
 serviceRegistry:

--- a/artifacts/settings/settings.yaml
+++ b/artifacts/settings/settings.yaml
@@ -1,4 +1,4 @@
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -35,10 +35,10 @@ import (
 // ServiceReconciler reconciles a Service object
 type ServiceReconciler struct {
 	client.Client
-	Log                      logr.Logger
-	Scheme                   *runtime.Scheme
-	ServRegBroker            *sr.Broker
-	EnableNamespaceByDefault bool
+	Log                        logr.Logger
+	Scheme                     *runtime.Scheme
+	ServRegBroker              *sr.Broker
+	MonitorNamespacesByDefault bool
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -82,13 +82,13 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	var shouldWatchNs bool
-	switch strings.ToLower(ns.Labels[enabledLabel]) {
-	case "yes":
+	switch strings.ToLower(ns.Labels[monitorLabel]) {
+	case "true":
 		shouldWatchNs = true
-	case "no":
+	case "false":
 		shouldWatchNs = false
 	default:
-		shouldWatchNs = r.EnableNamespaceByDefault
+		shouldWatchNs = r.MonitorNamespacesByDefault
 	}
 
 	if !shouldWatchNs {

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Cisco
+// Copyright © 2020, 2021 Cisco
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/CloudNativeSDWAN/cnwan-operator/internal/utils"
 	sr "github.com/CloudNativeSDWAN/cnwan-operator/pkg/servregistry"
 
-	cnwan_types "github.com/CloudNativeSDWAN/cnwan-operator/internal/types"
 	"github.com/go-logr/logr"
-	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,9 +35,10 @@ import (
 // ServiceReconciler reconciles a Service object
 type ServiceReconciler struct {
 	client.Client
-	Log           logr.Logger
-	Scheme        *runtime.Scheme
-	ServRegBroker *sr.Broker
+	Log                      logr.Logger
+	Scheme                   *runtime.Scheme
+	ServRegBroker            *sr.Broker
+	EnableNamespaceByDefault bool
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -69,6 +69,11 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		deleted = true
 	}
 
+	if r.ServRegBroker == nil {
+		l.Error(fmt.Errorf("%s", "service registry broker is nil"), "cannot handle service")
+		return ctrl.Result{}, nil
+	}
+
 	// Get the namespace
 	var ns corev1.Namespace
 	if err := r.Get(ctx, types.NamespacedName{Name: service.Namespace}, &ns); err != nil {
@@ -76,24 +81,18 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	nsListPolicy := cnwan_types.ListPolicy(viper.GetString(cnwan_types.NamespaceListPolicy))
-
-	if nsListPolicy == cnwan_types.AllowList {
-		if _, exists := ns.Labels[cnwan_types.AllowedKey]; !exists {
-			l.V(1).Info("ignoring service as namespace is not in the allow list")
-			return ctrl.Result{}, nil
-		}
+	var shouldWatchNs bool
+	switch strings.ToLower(ns.Labels[enabledLabel]) {
+	case "yes":
+		shouldWatchNs = true
+	case "no":
+		shouldWatchNs = false
+	default:
+		shouldWatchNs = r.EnableNamespaceByDefault
 	}
 
-	if nsListPolicy == cnwan_types.BlockList {
-		if _, exists := ns.Labels[cnwan_types.BlockedKey]; exists {
-			l.V(1).Info("ignoring service as namespace is in the block list")
-			return ctrl.Result{}, nil
-		}
-	}
-
-	if r.ServRegBroker == nil {
-		l.Error(fmt.Errorf("%s", "service registry broker is nil"), "cannot handle namespace")
+	if !shouldWatchNs {
+		l.V(1).Info("ignoring service as namespace is not in the allow list")
 		return ctrl.Result{}, nil
 	}
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -7,8 +7,7 @@
 * [Metadata](#metadata)
 * [Annotations vs Labels](#annotations-vs-labels)
 * [Ownership](#ownership)
-* [Namespace Lists](#namespace-lists)
-* [Namespace List Policy](#namespace-list-policy)
+* [Enable namespaces](#enable-namespaces)
 * [Allowed Annotations](#allowed-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Deploy](#deploy)
@@ -81,47 +80,31 @@ That being said, the operator will still insert child resources even if the pare
 
 Finally, if you wish the operator to manage your pre-existing resources on your service registry, please update all the necessary resources by inserting `owner: cnwan-operator` among their metadata.
 
-## Namespace Lists
+## Enable namespaces
 
-For the CN-WAN Operator, a namespace can belong to two lists: *allowlist* or *blocklist*. CN-WAN Operator only processes services that belong to namespaces it is allowed to work on: those that are inside the *allowlist*.
+The CN-WAN Operator watches service updates only on *enabled* namespaces. To do so, you need to label a namespace with our reserved label key `operator.cnwan.io/enabled`.
 
-To insert a namespace in a list, you have to label it like this:
+If a namespace is labeled as `operator.cnwan.io/enabled=yes` then the operator will watch service updates happening on that namespace. On the contrary, `operator.cnwan.io/enabled=no` will instruct the operator to stay away from that namespace.
 
-```bash
-# Insert namespace in the allowlist
-kubectl label ns namespace-name operator.cnwan.io/allowed=yes
+This being said, you don't need to rush labelling all namespaces as `operator.cnwan.io/enabled=no` in fear of potentially exposing sensitive data on the service registry: namespaces that do not have such label will be ignored by default, as the operator will pretend it is seeing `operator.cnwan.io/enabled=no`. This is useful in case you think you have few namespaces you want to enable or if you prefer to retain control, even have lots of namespaces to enable.
 
-# Insert namespace in the blocklist
-kubectl label ns namespace-name operator.cnwan.io/blocked=yes
-```
+Instead, if you have many namespaces to enable and/or find it tedious to manually do so for every single one of them, you can override this behavior via `enableNamespaceByDefault: true` on the [operator settings](./configuration.md#enable-namespace-by-default): this means that the operator will pretend it is seeing `operator.cnwan.io/enabled=yes` and thus watch events in the namespace by default, unless instructed otherwise. This is the opposite scenario from above: now you will need to manually *disable* them.
 
-It doesn't really matter what you put as value (in this case `yes` has been inserted), just as long as the key `operator.cnwan.io/<key>` is as specified above.
+Let's see some examples.
 
-Similarly, to remove a namespace from the list:
+To _enable_ monitoring on namespace `hr`, do the following:
 
 ```bash
-# Remove namespace from the allowlist
-kubectl label ns namespace-name operator.cnwan.io/allowed-
-
-# Remove namespace from the blocklist
-kubectl label ns namespace-name operator.cnwan.io/blocked-
+kubectl label ns hr operator.cnwan.io/enabled=yes
 ```
 
-To prevent you from manually inserting a namespace in a list each time, you can define the [Default Namespace List Policy](#namespace-list-policy).
+To _disable_ monitoring on namespace `hr`:
 
-## Namespace List Policy
+```bash
+kubectl label ns hr operator.cnwan.io/enabled=no
+```
 
-As we said, the operator watches for changes in Kubernetes services. While it does watch all services, it does **not** process services that belong to namespaces that the operator is not allowed to work on.
-
-To prevent you from manually allowing/blocking namespaces each time, the operator defines a *default namespace list policy*.
-
-Setting this default policy as `allowlist` means that, by default, all namespaces are **blocked** and the operator will work only on the ones you have specifically allowed. This is useful when you want few namespaces to be allowed or when you want to retain full control over which ones are allowed.
-
-In contrast, if you have a lot of namespaces that you want to enable, or you want the operator to work more "automatically", or you virtually want to enable all namespaces, than you can set the default policy as `blocklist` which means that, by default, all namespaces are **allowed** and you will have to specify only the ones that must be blocked.
-
-Refer to the previous section to know how to insert a namespace into a certain list.
-
-Please follow [this guide](./configuration.md#set-the-namespace-list-policy) to learn how to set up the default namespace list policy.
+Note: append `--overwrite` in case the label already exists.
 
 ## Allowed Annotations
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -7,7 +7,7 @@
 * [Metadata](#metadata)
 * [Annotations vs Labels](#annotations-vs-labels)
 * [Ownership](#ownership)
-* [Enable namespaces](#enable-namespaces)
+* [Monitor namespaces](#monitor-namespaces)
 * [Allowed Annotations](#allowed-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Deploy](#deploy)
@@ -80,28 +80,28 @@ That being said, the operator will still insert child resources even if the pare
 
 Finally, if you wish the operator to manage your pre-existing resources on your service registry, please update all the necessary resources by inserting `owner: cnwan-operator` among their metadata.
 
-## Enable namespaces
+## Monitor namespaces
 
-The CN-WAN Operator watches service updates only on *enabled* namespaces. To do so, you need to label a namespace with our reserved label key `operator.cnwan.io/enabled`.
+The CN-WAN Operator watches service updates only on *monitored* namespaces. To do so, you need to label a namespace with our reserved label key `operator.cnwan.io/monitor`.
 
-If a namespace is labeled as `operator.cnwan.io/enabled=yes` then the operator will watch service updates happening on that namespace. On the contrary, `operator.cnwan.io/enabled=no` will instruct the operator to stay away from that namespace.
+If a namespace is labeled as `operator.cnwan.io/monitor=true` then the operator will watch service updates happening on that namespace. On the contrary, `operator.cnwan.io/monitor=false` will instruct the operator to stay away from that namespace.
 
-This being said, you don't need to rush labelling all namespaces as `operator.cnwan.io/enabled=no` in fear of potentially exposing sensitive data on the service registry: namespaces that do not have such label will be ignored by default, as the operator will pretend it is seeing `operator.cnwan.io/enabled=no`. This is useful in case you think you have few namespaces you want to enable or if you prefer to retain control, even have lots of namespaces to enable.
+This being said, you don't need to rush labelling all namespaces as `operator.cnwan.io/monitor=false` in fear of potentially exposing sensitive data on the service registry: namespaces that do not have such label will be ignored by default, as the operator will pretend it is seeing `operator.cnwan.io/monitor=false`. This is useful in case you think you have few namespaces you want to monitor or if you prefer to retain control, even have lots of namespaces to monitor.
 
-Instead, if you have many namespaces to enable and/or find it tedious to manually do so for every single one of them, you can override this behavior via `enableNamespaceByDefault: true` on the [operator settings](./configuration.md#enable-namespace-by-default): this means that the operator will pretend it is seeing `operator.cnwan.io/enabled=yes` and thus watch events in the namespace by default, unless instructed otherwise. This is the opposite scenario from above: now you will need to manually *disable* them.
+Instead, if you have many namespaces to monitor and/or find it tedious to manually do so for every single one of them, you can override this behavior via `monitorNamespacesByDefault: true` on the [operator settings](./configuration.md#monitor-namespaces-by-default): this means that the operator will pretend it is seeing `operator.cnwan.io/monitor=true` and thus watch events in the namespace by default, unless instructed otherwise. This is the opposite scenario from above: now you will need to manually *disable* them.
 
 Let's see some examples.
 
 To _enable_ monitoring on namespace `hr`, do the following:
 
 ```bash
-kubectl label ns hr operator.cnwan.io/enabled=yes
+kubectl label ns hr operator.cnwan.io/monitor=true
 ```
 
 To _disable_ monitoring on namespace `hr`:
 
 ```bash
-kubectl label ns hr operator.cnwan.io/enabled=no
+kubectl label ns hr operator.cnwan.io/monitor=false
 ```
 
 Note: append `--overwrite` in case the label already exists.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ This section will guide you through the steps you need to take to configure the 
 ## Table of Contents
 
 * [Format](#format)
-* [Set the Namespace List Policy](#set-the-namespace-list-policy)
+* [Enable namespace by default](#enable-namespace-by-default)
 * [Allow Annotations](#allow-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Service registry settings](#service-registry-settings)
@@ -17,10 +17,8 @@ This section will guide you through the steps you need to take to configure the 
 The CN-WAN Operator can be configured with the following YAML format.
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations: []
+enableNamespaceByDefault: false
+serviceAnnotations: []
 serviceRegistry:
   etcd:
     prefix: <prefix>
@@ -38,18 +36,13 @@ cloudMetadata:
   subNetwork: auto
 ```
 
-## Set the Namespace List Policy
+## Enable namespace by default
 
-The operator will only monitor services that belong to a namespace that you have explicitly allowed.
+The operator will watch service events only on namespaces that are *enabled*, and to do so you need to explicitly label namespaces with the reserved `operator.cnwan.io/enabled` label key.
 
-if you haven't already, please take a look at [this section](./concepts.md#namespace-list-policy) to learn more about the *default namespace list policy*.
+`enableNamespaceByDefault` will tell the operator what to do when such label is not found: if it does not exist or is false, then the operator will ignore the namespace by default. Otherwise it will watch events inside it.
 
-To set the list policy, change `listPolicy` value to either `allowlist` or `blocklist` like so:
-
-```yaml
-namespace:
-  listPolicy: allowlist
-```
+if you haven't already, please take a look at [this section](./concepts.md#enable-namespaces) to learn more about this concept.
 
 ## Allow Annotations
 
@@ -57,13 +50,18 @@ The operator will not register every annotation as metadata from a Kubernetes Se
 
 if you haven't already, please take a look at [Metadata](./concepts.md#metadata), [Allowed Annotations](./concepts.md#allowed-annotations) and [Annotations vs Labels](./concepts.md#annotations-vs-labels) to learn more.
 
-You can allow annotations by setting up `service.annotations` in the configuration. For example:
+You can allow annotations by setting up `serviceAnnotations` in the configuration. For example:
 
 ```yaml
-service:
-  annotations:
+serviceAnnotations:
   - version
   - example.com/purpose
+```
+
+Or you may like this format better:
+
+```yaml
+serviceAnnotations: [version, example.com/purpose]
 ```
 
 Values can also have wildcards. Example of accepted values are:
@@ -100,7 +98,7 @@ my.prefix.com/another-name: another-value
 name-with-no-prefix: simple-value
 ```
 
-Finally, if you leave this empty - as `annotations: []`, then no service will match this and, therefore, no service will be registered.
+Finally, if you leave this empty - as `serviceAnnotations: []`, then no service will match this and, therefore, no service will be registered.
 
 ## Cloud Metadata
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ This section will guide you through the steps you need to take to configure the 
 ## Table of Contents
 
 * [Format](#format)
-* [Enable namespace by default](#enable-namespace-by-default)
+* [Monitor namespaces by default](#monitor-namespace-by-default)
 * [Allow Annotations](#allow-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Service registry settings](#service-registry-settings)
@@ -17,7 +17,7 @@ This section will guide you through the steps you need to take to configure the 
 The CN-WAN Operator can be configured with the following YAML format.
 
 ```yaml
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -36,13 +36,13 @@ cloudMetadata:
   subNetwork: auto
 ```
 
-## Enable namespace by default
+## Monitor namespace by default
 
-The operator will watch service events only on namespaces that are *enabled*, and to do so you need to explicitly label namespaces with the reserved `operator.cnwan.io/enabled` label key.
+The operator will watch service events only on namespaces that are *monitored*, and to do so you need to explicitly label namespaces with the reserved `operator.cnwan.io/monitor` label key.
 
-`enableNamespaceByDefault` will tell the operator what to do when such label is not found: if it does not exist or is false, then the operator will ignore the namespace by default. Otherwise it will watch events inside it.
+`monitorNamespacesByDefault` will tell the operator what to do when such label is not found: if it does not exist or is false, then the operator will ignore the namespace by default. Otherwise it will watch events inside it.
 
-if you haven't already, please take a look at [this section](./concepts.md#enable-namespaces) to learn more about this concept.
+if you haven't already, please take a look at [this section](./concepts.md#monitor-namespaces) to learn more about this concept.
 
 ## Allow Annotations
 

--- a/docs/etcd/operator_configuration.md
+++ b/docs/etcd/operator_configuration.md
@@ -9,7 +9,7 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -28,7 +28,7 @@ serviceRegistry:
 We will only cover etcd settings here, so you can go ahead and remove the whole `gcpServiceDirectory` settings:
 
 ```yaml
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:

--- a/docs/etcd/operator_configuration.md
+++ b/docs/etcd/operator_configuration.md
@@ -9,10 +9,8 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations: []
+enableNamespaceByDefault: false
+serviceAnnotations: []
 serviceRegistry:
   etcd:
     prefix: <prefix>
@@ -30,10 +28,8 @@ serviceRegistry:
 We will only cover etcd settings here, so you can go ahead and remove the whole `gcpServiceDirectory` settings:
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations: []
+enableNamespaceByDefault: false
+serviceAnnotations: []
 serviceRegistry:
   etcd:
     prefix: <prefix>

--- a/docs/etcd/quickstart.md
+++ b/docs/etcd/quickstart.md
@@ -39,7 +39,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/enabled: "yes"
+        operator.cnwan.io/monitor: "true"
 ---
 kind: Service
 apiVersion: v1
@@ -63,7 +63,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/enabled: yes` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/monitor: true` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -97,7 +97,7 @@ It doesn't really matter that there is no pod backing this service for now, as t
 From the root directory navigate to `deploy/settings` and modify the file `settings.yaml` to look like this - please provide appropriate values for `host` and `port` keys with your etcd cluster's addresses:
 
 ```yaml
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 servicennotations:
   - traffic-profile
   - version

--- a/docs/etcd/quickstart.md
+++ b/docs/etcd/quickstart.md
@@ -39,7 +39,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/allowed: "yes"
+        operator.cnwan.io/enabled: "yes"
 ---
 kind: Service
 apiVersion: v1
@@ -63,7 +63,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/allowed: yes` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/enabled: yes` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -97,10 +97,8 @@ It doesn't really matter that there is no pod backing this service for now, as t
 From the root directory navigate to `deploy/settings` and modify the file `settings.yaml` to look like this - please provide appropriate values for `host` and `port` keys with your etcd cluster's addresses:
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations:
+enableNamespaceByDefault: false
+servicennotations:
   - traffic-profile
   - version
 serviceRegistry:
@@ -120,10 +118,10 @@ endpoints:
 - host: 10.10.10.10
 ```
 
-Please notice the values inside `annotations`:
+Please notice the values inside `serviceAnnotations`:
 
 ```yaml
-  annotations:
+  serviceAnnotations:
   - traffic-profile
   - version
 ```

--- a/docs/gcp_service_directory/configure_with_operator.md
+++ b/docs/gcp_service_directory/configure_with_operator.md
@@ -9,7 +9,7 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-enableNamespaceByDefaut: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -28,7 +28,7 @@ serviceRegistry:
 We will only cover Service Directory settings here, so you can go ahead and remove the whole `etcd` settings:
 
 ```yaml
-enableNamespaceByDefaut: false
+monitorNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   gcpServiceDirectory:

--- a/docs/gcp_service_directory/configure_with_operator.md
+++ b/docs/gcp_service_directory/configure_with_operator.md
@@ -9,10 +9,8 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations: []
+enableNamespaceByDefaut: false
+serviceAnnotations: []
 serviceRegistry:
   etcd:
     prefix: <prefix>
@@ -30,10 +28,8 @@ serviceRegistry:
 We will only cover Service Directory settings here, so you can go ahead and remove the whole `etcd` settings:
 
 ```yaml
-namespace:
-  listPolicy: allowlist
-service:
-  annotations: []
+enableNamespaceByDefaut: false
+serviceAnnotations: []
 serviceRegistry:
   gcpServiceDirectory:
     defaultRegion: <region>

--- a/docs/gcp_service_directory/quickstart.md
+++ b/docs/gcp_service_directory/quickstart.md
@@ -41,7 +41,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/allowed: "yes"
+        operator.cnwan.io/enabled: "yes"
 ---
 kind: Service
 apiVersion: v1
@@ -65,7 +65,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/allowed: yes` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/enabled: yes` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -107,10 +107,8 @@ serviceRegistry:
   gcpServiceDirectory:
     defaultRegion: <gcloud-region>
     projectID: <gcloud-project-id>
-namespace:
-  listPolicy: allowlist
-service:
-  annotations:
+enableNamespaceByDefault: false
+serviceAnnotations:
   - traffic-profile
   - version
 ```
@@ -129,10 +127,8 @@ If you plan to run the operator in GKE, you can just write:
 ```yaml
 serviceRegistry:
   gcpServiceDirectory: {}
-namespace:
-  listPolicy: allowlist
-service:
-  annotations:
+enableNamespaceByDefault: false
+serviceAnnotations:
   - traffic-profile
   - version
 ```

--- a/docs/gcp_service_directory/quickstart.md
+++ b/docs/gcp_service_directory/quickstart.md
@@ -41,7 +41,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/enabled: "yes"
+        operator.cnwan.io/monitor: "true"
 ---
 kind: Service
 apiVersion: v1
@@ -65,7 +65,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/enabled: yes` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/monitor: true` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -107,7 +107,7 @@ serviceRegistry:
   gcpServiceDirectory:
     defaultRegion: <gcloud-region>
     projectID: <gcloud-project-id>
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations:
   - traffic-profile
   - version
@@ -127,7 +127,7 @@ If you plan to run the operator in GKE, you can just write:
 ```yaml
 serviceRegistry:
   gcpServiceDirectory: {}
-enableNamespaceByDefault: false
+monitorNamespacesByDefault: false
 serviceAnnotations:
   - traffic-profile
   - version

--- a/docs/install.md
+++ b/docs/install.md
@@ -47,7 +47,7 @@ Before deploying the operator you will need to configure it.
 
 ### Settings
 
-Modify the file `deploy/settings/settings.yaml` with the appropriate values. If you haven't already, please read [Configuration](./configuration.md) to learn how to do this.
+Modify the file `artifacts/deploy/settings/settings.yaml` with the appropriate values. If you haven't already, please read [Configuration](./configuration.md) to learn how to do this.
 
 ## Deploy
 
@@ -58,7 +58,7 @@ Before continuing, if you also have other files that you want to be deployed, yo
 To deploy the operator with the provided script, you will have to execute `deploy.sh` as such:
 
 ```bash
-./scripts/deploy.sh <service-registry>
+./scripts/deploy.sh etcd|servicedirectory
 ```
 
 If you want to use your own image, you'll need to provide `--image` flag, for example:

--- a/docs/update.md
+++ b/docs/update.md
@@ -28,6 +28,13 @@ and you should see
 deployment.apps/cnwan-operator-controller-manager image updated
 ```
 
+<!-- TODO: write an update guide for v0.6.0 when it is going to be released:
+- clone operator
+- remove it
+- script to replace the old labels with new one
+- change the settings
+ -->
+
 ## 0.2.1 and below
 
 Clone latest `v0.2.x` version and navigate to `/scripts folder to remove it:

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -43,7 +43,7 @@ const (
 // Settings of the application
 type Settings struct {
 	EnableNamespaceByDefault bool            `yaml:"enableNamespaceByDefault"`
-	Service                  ServiceSettings `yaml:"service"`
+	Service                  ServiceSettings `yaml:",inline"`
 	*ServiceRegistrySettings `yaml:"serviceRegistry"`
 
 	// DEPRECATED: include this under serviceRegistry instead of here.
@@ -60,7 +60,7 @@ type GcloudSettings struct {
 
 // ServiceSettings includes settings about services
 type ServiceSettings struct {
-	Annotations []string `yaml:"annotations"`
+	Annotations []string `yaml:"serviceAnnotations"`
 }
 
 // ServiceRegistrySettings contains information about the service registry

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -42,9 +42,9 @@ const (
 
 // Settings of the application
 type Settings struct {
-	EnableNamespaceByDefault bool            `yaml:"enableNamespaceByDefault"`
-	Service                  ServiceSettings `yaml:",inline"`
-	*ServiceRegistrySettings `yaml:"serviceRegistry"`
+	MonitorNamespacesByDefault bool            `yaml:"monitorNamespacesByDefault"`
+	Service                    ServiceSettings `yaml:",inline"`
+	*ServiceRegistrySettings   `yaml:"serviceRegistry"`
 
 	// DEPRECATED: include this under serviceRegistry instead of here.
 	// TODO: remove this on v0.6.0

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -21,8 +21,6 @@ const (
 	SDDefaultRegion = "gcloud.servicedirectory.region"
 	// SDProject is the key for service directory project setting
 	SDProject = "gcloud.servicedirectory.project"
-	// NamespaceListPolicy is the key for the namespace list policy setting
-	NamespaceListPolicy = "namespace.listpolicy"
 	// AllowedAnnotations is the key for the allowed annotations setting
 	AllowedAnnotations = "service.annotations"
 	// AllowedAnnotationsMap is the key for the allowed annotations map setting
@@ -44,8 +42,8 @@ const (
 
 // Settings of the application
 type Settings struct {
-	Namespace                NamespaceSettings `yaml:"namespace"`
-	Service                  ServiceSettings   `yaml:"service"`
+	EnableNamespaceByDefault bool            `yaml:"enableNamespaceByDefault"`
+	Service                  ServiceSettings `yaml:"service"`
 	*ServiceRegistrySettings `yaml:"serviceRegistry"`
 
 	// DEPRECATED: include this under serviceRegistry instead of here.
@@ -58,31 +56,6 @@ type Settings struct {
 // TODO: remove this on v0.6.0
 type GcloudSettings struct {
 	ServiceDirectory *DeprecatedServiceDirectorySettings `yaml:"serviceDirectory"`
-}
-
-// ListPolicy is the list type that must be adopted by the operator
-type ListPolicy string
-
-const (
-	// AllowList will make the operator only consider resources that have
-	// are in the allowlist
-	AllowList ListPolicy = "allowlist"
-	// AllowedKey is the label key that states that a specific resource is
-	// in the allowlist, if allowlist is the current policy type.
-	// If the policy type is blocklist, this key is ignored.
-	AllowedKey string = "operator.cnwan.io/allowed"
-	// BlockList will make the operator consider all resources and ignore
-	// those that are in the blocklist
-	BlockList ListPolicy = "blocklist"
-	// BlockedKey is the label key that states that a specific resource is
-	// in the blocklist, if blocklist is the current policy type.
-	// If the policy type is allowlist, this key is ignored.
-	BlockedKey string = "operator.cnwan.io/blocked"
-)
-
-// NamespaceSettings includes settings about namespaces
-type NamespaceSettings struct {
-	ListPolicy ListPolicy `yaml:"listPolicy"`
 }
 
 // ServiceSettings includes settings about services

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -82,7 +82,7 @@ func ParseAndValidateSettings(settings *types.Settings) (*types.Settings, error)
 		return nil, fmt.Errorf("no settings provided")
 	}
 
-	finalSettings := &types.Settings{}
+	finalSettings := &types.Settings{EnableNamespaceByDefault: settings.EnableNamespaceByDefault}
 	if settings.CloudMetadata != nil {
 		clCfg := settings.CloudMetadata
 		finalCfg := &types.CloudMetadata{}
@@ -98,14 +98,6 @@ func ParseAndValidateSettings(settings *types.Settings) (*types.Settings, error)
 			finalSettings.CloudMetadata = finalCfg
 		}
 	}
-
-	if settings.Namespace.ListPolicy != types.AllowList && settings.Namespace.ListPolicy != types.BlockList {
-		// Probably we could revert to using a default value here, but I think
-		// it's better not to confuse the user with unexpected behaviors and
-		// just return an error.
-		return nil, fmt.Errorf("namespace list policy is neither AllowList nor BlockList")
-	}
-	finalSettings.Namespace = settings.Namespace
 
 	if len(settings.Service.Annotations) == 0 {
 		log.V(int(zapcore.WarnLevel)).Info("no allowed annotations provided: no service will be registered")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -82,7 +82,7 @@ func ParseAndValidateSettings(settings *types.Settings) (*types.Settings, error)
 		return nil, fmt.Errorf("no settings provided")
 	}
 
-	finalSettings := &types.Settings{EnableNamespaceByDefault: settings.EnableNamespaceByDefault}
+	finalSettings := &types.Settings{MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault}
 	if settings.CloudMetadata != nil {
 		clCfg := settings.CloudMetadata
 		finalCfg := &types.CloudMetadata{}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -113,39 +113,21 @@ func TestParseAndValidateSettings(t *testing.T) {
 			expErr: fmt.Errorf("no settings provided"),
 		},
 		{
-			id: "unknown-ns-settings",
-			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.ListPolicy("unknwon"),
-				},
-			},
-			expErr: fmt.Errorf("namespace list policy is neither AllowList nor BlockList"),
-		},
-		{
-			id: "no-service-registry-settings",
-			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
-			},
+			id:     "no-service-registry-settings",
+			arg:    &types.Settings{EnableNamespaceByDefault: true},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
 		{
 			id: "no-service-registry-fields",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
-				ServiceRegistrySettings: &types.ServiceRegistrySettings{},
+				EnableNamespaceByDefault: true,
+				ServiceRegistrySettings:  &types.ServiceRegistrySettings{},
 			},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
 		{
 			id: "etcd-unknown-auth",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthenticationType("nothing"),
@@ -160,9 +142,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "etcd-uname-pass-auth",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -173,9 +153,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -189,9 +167,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "etcd-tls-auth",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithTLS,
@@ -206,9 +181,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "only-etcd-not-empty",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Prefix: &pref,
@@ -223,9 +195,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithNothing,
@@ -242,9 +211,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "only-etcd-empty",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{},
 				},
@@ -254,9 +220,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "both-but-only-etcd-is-there",
 			arg: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -270,9 +234,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -294,18 +256,14 @@ func TestParseAndValidateSettings(t *testing.T) {
 						DefaultRegion: "ca",
 					},
 				},
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -326,9 +284,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 						DefaultRegion: "old",
 					},
 				},
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -340,9 +296,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
+				EnableNamespaceByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -362,9 +316,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 						ProjectName:   "old",
 						DefaultRegion: "old",
 					},
-				},
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
 				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
@@ -387,9 +338,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -418,9 +366,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 						DefaultRegion: "old",
 					},
 				},
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -433,9 +378,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 				CloudMetadata: &types.CloudMetadata{},
 			},
 			expRes: &types.Settings{
-				Namespace: types.NamespaceSettings{
-					ListPolicy: types.AllowList,
-				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -114,14 +114,14 @@ func TestParseAndValidateSettings(t *testing.T) {
 		},
 		{
 			id:     "no-service-registry-settings",
-			arg:    &types.Settings{EnableNamespaceByDefault: true},
+			arg:    &types.Settings{MonitorNamespacesByDefault: true},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
 		{
 			id: "no-service-registry-fields",
 			arg: &types.Settings{
-				EnableNamespaceByDefault: true,
-				ServiceRegistrySettings:  &types.ServiceRegistrySettings{},
+				MonitorNamespacesByDefault: true,
+				ServiceRegistrySettings:    &types.ServiceRegistrySettings{},
 			},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
@@ -142,7 +142,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "etcd-uname-pass-auth",
 			arg: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -153,7 +153,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -220,7 +220,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "both-but-only-etcd-is-there",
 			arg: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -234,7 +234,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -256,14 +256,14 @@ func TestParseAndValidateSettings(t *testing.T) {
 						DefaultRegion: "ca",
 					},
 				},
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{},
 			},
 			expRes: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -284,7 +284,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 						DefaultRegion: "old",
 					},
 				},
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -296,7 +296,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				EnableNamespaceByDefault: true,
+				MonitorNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},

--- a/main.go
+++ b/main.go
@@ -210,22 +210,22 @@ func main() {
 	}
 
 	if err = (&controllers.ServiceReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      ctrl.Log.WithName("controllers").WithName("Service"),
-		Scheme:                   mgr.GetScheme(),
-		ServRegBroker:            srBroker,
-		EnableNamespaceByDefault: settings.EnableNamespaceByDefault,
+		Client:                     mgr.GetClient(),
+		Log:                        ctrl.Log.WithName("controllers").WithName("Service"),
+		Scheme:                     mgr.GetScheme(),
+		ServRegBroker:              srBroker,
+		MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		returnCode = 8
 		runtime.Goexit()
 	}
 	if err = (&controllers.NamespaceReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      ctrl.Log.WithName("controllers").WithName("Namespace"),
-		Scheme:                   mgr.GetScheme(),
-		ServRegBroker:            srBroker,
-		EnableNamespaceByDefault: settings.EnableNamespaceByDefault,
+		Client:                     mgr.GetClient(),
+		Log:                        ctrl.Log.WithName("controllers").WithName("Namespace"),
+		Scheme:                     mgr.GetScheme(),
+		ServRegBroker:              srBroker,
+		MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		returnCode = 9

--- a/main.go
+++ b/main.go
@@ -127,7 +127,6 @@ func main() {
 		allowedAnnotations[ann] = true
 	}
 	viper.Set(types.AllowedAnnotationsMap, allowedAnnotations)
-	viper.Set(types.NamespaceListPolicy, settings.Namespace.ListPolicy)
 	viper.Set(types.CurrentNamespace, nsName)
 
 	persistentMeta := []sr.MetadataPair{}
@@ -211,20 +210,22 @@ func main() {
 	}
 
 	if err = (&controllers.ServiceReconciler{
-		Client:        mgr.GetClient(),
-		Log:           ctrl.Log.WithName("controllers").WithName("Service"),
-		Scheme:        mgr.GetScheme(),
-		ServRegBroker: srBroker,
+		Client:                   mgr.GetClient(),
+		Log:                      ctrl.Log.WithName("controllers").WithName("Service"),
+		Scheme:                   mgr.GetScheme(),
+		ServRegBroker:            srBroker,
+		EnableNamespaceByDefault: settings.EnableNamespaceByDefault,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		returnCode = 8
 		runtime.Goexit()
 	}
 	if err = (&controllers.NamespaceReconciler{
-		Client:        mgr.GetClient(),
-		Log:           ctrl.Log.WithName("controllers").WithName("Namespace"),
-		Scheme:        mgr.GetScheme(),
-		ServRegBroker: srBroker,
+		Client:                   mgr.GetClient(),
+		Log:                      ctrl.Log.WithName("controllers").WithName("Namespace"),
+		Scheme:                   mgr.GetScheme(),
+		ServRegBroker:            srBroker,
+		EnableNamespaceByDefault: settings.EnableNamespaceByDefault,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		returnCode = 9


### PR DESCRIPTION
## TL;DR

- New setting `enableNamespaceByDefault`: 
  - if false => ignore namespace
  - if true => watch namespace
- New label `operator.cnwan.io/enabled=yes|no`.
  - `yes`: watch the namespace
  - `no`: stay away from namespace
  - name is very fitting and can be used to filter other resources in future (e.g. enable *this* namespace but disable *this* service under it)

## Description

This PR closes #15 and improves the current way a namespace is blocked/allowed. Read the issue for more information, although the changes have been applied in a slightly different way.

This provides a much simpler way to filter namespaces that must be ignored or watched by the operator: there is no more concept of *allowlist* or *blocklist*, and there is a more descriptive label.

You just need to label the namespace as `operator.cnwan.io/enabled` with either `yes` and the operator will watch service updates on this namespace or `no` and the operator will stay away from it. This replaces the old `operator.cnwan.io/allowed` and `operator.cnwan.io/blocked` as they were redundant and made the value irrelevant (it was basically ignored). Again read the issue for more information about why I consider it a bad practice.

If such a label is not found, then the operator will pretend it saw `operator.cnwan.io/enabled=no`, unless `enableNamespaceByDefault` is set to true on the operator's settings, in which case it will pretend it saw `operator.cnwan.io/enabled=yes`.

Finally, this fixes some other minor bugs found while developing the feature.

## Status

- [x] Replace old `namespaceListPolicy` setting with a simple `enableNamespaceByDefault` boolean one
- [x] Replace old labels with `operator.cnwan.io/enabled` labels
- [x] Update controllers
- [x] Update unit tests
- [x] Update documentation

