### PR TITLE
Prepare project for v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build the manager binary
+# Build binary
 FROM golang:1.17 as builder
 
 WORKDIR /workspace
@@ -17,15 +17,15 @@ COPY pkg/ pkg/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager *.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o cnwan-operator *.go
 
-# Use distroless as minimal base image to package the manager binary
+# Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/cnwan-operator .
 USER nonroot:nonroot
 
 LABEL project="CNWAN-operator"
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/cnwan-operator"]

--- a/artifacts/deploy/07_deployment.yaml.tpl
+++ b/artifacts/deploy/07_deployment.yaml.tpl
@@ -5,7 +5,7 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: cnwan-operator-controller-manager
+  name: cnwan-operator
   namespace: cnwan-operator-system
   labels:
     control-plane: controller-manager

--- a/artifacts/settings/settings.yaml
+++ b/artifacts/settings/settings.yaml
@@ -1,4 +1,4 @@
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -34,11 +34,11 @@ import (
 // ServiceReconciler reconciles a Service object
 type ServiceReconciler struct {
 	client.Client
-	Log                        logr.Logger
-	Scheme                     *runtime.Scheme
-	ServRegBroker              *sr.Broker
-	MonitorNamespacesByDefault bool
-	AllowedAnnotations         []string
+	Log                      logr.Logger
+	Scheme                   *runtime.Scheme
+	ServRegBroker            *sr.Broker
+	WatchNamespacesByDefault bool
+	AllowedAnnotations       []string
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -82,13 +82,13 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	var shouldWatchNs bool
-	switch strings.ToLower(ns.Labels[monitorLabel]) {
-	case "true":
+	switch strings.ToLower(ns.Labels[watchLabel]) {
+	case "enabled":
 		shouldWatchNs = true
-	case "false":
+	case "disabled":
 		shouldWatchNs = false
 	default:
-		shouldWatchNs = r.MonitorNamespacesByDefault
+		shouldWatchNs = r.WatchNamespacesByDefault
 	}
 
 	if !shouldWatchNs {

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -7,7 +7,7 @@
 * [Metadata](#metadata)
 * [Annotations vs Labels](#annotations-vs-labels)
 * [Ownership](#ownership)
-* [Monitor namespaces](#monitor-namespaces)
+* [Watch namespaces](#watch-namespaces)
 * [Allowed Annotations](#allowed-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Deploy](#deploy)
@@ -80,28 +80,28 @@ That being said, the operator will still insert child resources even if the pare
 
 Finally, if you wish the operator to manage your pre-existing resources on your service registry, please update all the necessary resources by inserting `owner: cnwan-operator` among their metadata.
 
-## Monitor namespaces
+## Watch namespaces
 
-The CN-WAN Operator watches service updates only on *monitored* namespaces. To do so, you need to label a namespace with our reserved label key `operator.cnwan.io/monitor`.
+The CN-WAN Operator observes service updates only on *watched* namespaces. To do so, you need to label a namespace with our reserved label key `operator.cnwan.io/watch`.
 
-If a namespace is labeled as `operator.cnwan.io/monitor=true` then the operator will watch service updates happening on that namespace. On the contrary, `operator.cnwan.io/monitor=false` will instruct the operator to stay away from that namespace.
+If a namespace is labeled as `operator.cnwan.io/watch=enabled` then the operator will watch service updates happening on that namespace. On the contrary, `operator.cnwan.io/watch=disabled` will instruct the operator to stay away from that namespace.
 
-This being said, you don't need to rush labelling all namespaces as `operator.cnwan.io/monitor=false` in fear of potentially exposing sensitive data on the service registry: namespaces that do not have such label will be ignored by default, as the operator will pretend it is seeing `operator.cnwan.io/monitor=false`. This is useful in case you think you have few namespaces you want to monitor or if you prefer to retain control, even have lots of namespaces to monitor.
+This being said, you don't need to rush labelling all namespaces as `operator.cnwan.io/watch=disabled` in fear of potentially exposing sensitive data on the service registry: namespaces that do not have such label will be ignored by default, as the operator will pretend it is seeing `operator.cnwan.io/watch=disabled`. This is useful in case you think you have few namespaces you want to watch or if you prefer to retain control, even have lots of namespaces to watch.
 
-Instead, if you have many namespaces to monitor and/or find it tedious to manually do so for every single one of them, you can override this behavior via `monitorNamespacesByDefault: true` on the [operator settings](./configuration.md#monitor-namespaces-by-default): this means that the operator will pretend it is seeing `operator.cnwan.io/monitor=true` and thus watch events in the namespace by default, unless instructed otherwise. This is the opposite scenario from above: now you will need to manually *disable* them.
+Instead, if you have many namespaces to watch and/or find it tedious to manually do so for every single one of them, you can override this behavior via `watchNamespacesByDefault: true` on the [operator settings](./configuration.md#watch-namespaces-by-default): this means that the operator will pretend it is seeing `operator.cnwan.io/watch=enabled` and thus watch events in the namespace by default, unless instructed otherwise. This is the opposite scenario from above: now you will need to manually *disable* them.
 
 Let's see some examples.
 
-To _enable_ monitoring on namespace `hr`, do the following:
+To _enable_ watching on namespace `hr`, do the following:
 
 ```bash
-kubectl label ns hr operator.cnwan.io/monitor=true
+kubectl label ns hr operator.cnwan.io/watch=enabled
 ```
 
-To _disable_ monitoring on namespace `hr`:
+To _disable_ watching on namespace `hr`:
 
 ```bash
-kubectl label ns hr operator.cnwan.io/monitor=false
+kubectl label ns hr operator.cnwan.io/watch=disabled
 ```
 
 Note: append `--overwrite` in case the label already exists.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ This section will guide you through the steps you need to take to configure the 
 ## Table of Contents
 
 * [Format](#format)
-* [Monitor namespaces by default](#monitor-namespace-by-default)
+* [Watch namespaces by default](#watch-namespaces-by-default)
 * [Allow Annotations](#allow-annotations)
 * [Cloud Metadata](#cloud-metadata)
 * [Service registry settings](#service-registry-settings)
@@ -17,7 +17,7 @@ This section will guide you through the steps you need to take to configure the 
 The CN-WAN Operator can be configured with the following YAML format.
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -36,13 +36,13 @@ cloudMetadata:
   subNetwork: auto
 ```
 
-## Monitor namespace by default
+## Watch namespaces by default
 
-The operator will watch service events only on namespaces that are *monitored*, and to do so you need to explicitly label namespaces with the reserved `operator.cnwan.io/monitor` label key.
+The operator will observe service events only on namespaces that are *watched*, and to do so you need to explicitly label namespaces with the reserved `operator.cnwan.io/watch` label key.
 
-`monitorNamespacesByDefault` will tell the operator what to do when such label is not found: if it does not exist or is false, then the operator will ignore the namespace by default. Otherwise it will watch events inside it.
+`watchNamespacesByDefault` will tell the operator what to do when such label is not found: if it does not exist or is false, then the operator will ignore the namespace by default. Otherwise it will watch events inside it.
 
-if you haven't already, please take a look at [this section](./concepts.md#monitor-namespaces) to learn more about this concept.
+if you haven't already, please take a look at [this section](./concepts.md#watch-namespaces) to learn more about this concept.
 
 ## Allow Annotations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ If successful, you will have to restart the operator for it to be able to acknow
 
 ```bash
 # For Kubernetes 1.15+
-kubectl rollout restart deployment cnwan-operator-controller-manager -n cnwan-operator-system
+kubectl rollout restart deployment cnwan-operator -n cnwan-operator-system
 ```
 
 In case your Kubernetes version is lower, than you will have to either delete the pod or scale down the deployment:

--- a/docs/etcd/operator_configuration.md
+++ b/docs/etcd/operator_configuration.md
@@ -9,7 +9,7 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -28,7 +28,7 @@ serviceRegistry:
 We will only cover etcd settings here, so you can go ahead and remove the whole `gcpServiceDirectory` settings:
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:

--- a/docs/etcd/quickstart.md
+++ b/docs/etcd/quickstart.md
@@ -39,7 +39,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/monitor: "true"
+        operator.cnwan.io/watch: "enabled"
 ---
 kind: Service
 apiVersion: v1
@@ -63,7 +63,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/monitor: true` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/watch: enabled` which inserts the namespace in the opeartor's [allowlist](../concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](../concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -97,7 +97,7 @@ It doesn't really matter that there is no pod backing this service for now, as t
 From the root directory navigate to `deploy/settings` and modify the file `settings.yaml` to look like this - please provide appropriate values for `host` and `port` keys with your etcd cluster's addresses:
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 servicennotations:
   - traffic-profile
   - version

--- a/docs/gcp_service_directory/configure_with_operator.md
+++ b/docs/gcp_service_directory/configure_with_operator.md
@@ -9,7 +9,7 @@ The included directory `deploy/settings` contains a `settings.yaml` for you to m
 For your convenience, here is how the settings for the CN-WAN Operator looks like:
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   etcd:
@@ -28,7 +28,7 @@ serviceRegistry:
 We will only cover Service Directory settings here, so you can go ahead and remove the whole `etcd` settings:
 
 ```yaml
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations: []
 serviceRegistry:
   gcpServiceDirectory:

--- a/docs/gcp_service_directory/quickstart.md
+++ b/docs/gcp_service_directory/quickstart.md
@@ -41,7 +41,7 @@ metadata:
     name: training-app-namespace
     labels:
         purpose: "test"
-        operator.cnwan.io/monitor: "true"
+        operator.cnwan.io/watch: "enabled"
 ---
 kind: Service
 apiVersion: v1
@@ -65,7 +65,7 @@ spec:
 EOF
 ```
 
-Please notice that the namespace has this label: `operator.cnwan.io/monitor: true` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
+Please notice that the namespace has this label: `operator.cnwan.io/watch: enabled` which inserts the namespace in the opeartor's [allowlist](./concepts.md#namespace-lists). Also notice that the service has annotations that will be registered as [metadata](./concepts.md#metadata):
 
 ```yaml
 annotations:
@@ -107,7 +107,7 @@ serviceRegistry:
   gcpServiceDirectory:
     defaultRegion: <gcloud-region>
     projectID: <gcloud-project-id>
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations:
   - traffic-profile
   - version
@@ -127,7 +127,7 @@ If you plan to run the operator in GKE, you can just write:
 ```yaml
 serviceRegistry:
   gcpServiceDirectory: {}
-monitorNamespacesByDefault: false
+watchNamespacesByDefault: false
 serviceAnnotations:
   - traffic-profile
   - version

--- a/docs/update.md
+++ b/docs/update.md
@@ -24,14 +24,14 @@ Remove the operator:
 ./scripts/remove.sh
 ```
 
-`monitorNamespacesByDefault` on the settings needs to be set as `true` if your previous value of `namespace.listPolicy` was `blocklist`, otherwise you can just leave it as it is.
+`watchNamespacesByDefault` on the settings needs to be set as `true` if your previous value of `namespace.listPolicy` was `blocklist`, otherwise you can just leave it as it is.
 
 Now, if your previous value of `namespace.listPolicy` was `allowlist` run:
 
 ```bash
 for ns in $(kubectl get ns -l "operator.cnwan.io/allowed" -o jsonpath="{.items[*].metadata.name}")
 do
-kubectl label ns $ns operator.cnwan.io/monitor=true
+kubectl label ns $ns operator.cnwan.io/watch=enabled
 kubectl label ns $ns operator.cnwan.io/allowed-
 done
 ```
@@ -41,17 +41,10 @@ Or, if it was `blocklist`:
 ```bash
 for ns in $(kubectl get ns -l "operator.cnwan.io/blocked" -o jsonpath="{.items[*].metadata.name}")
 do
-kubectl label ns $ns operator.cnwan.io/monitor=false
+kubectl label ns $ns operator.cnwan.io/watch=disabled
 kubectl label ns $ns operator.cnwan.io/blocked-
 done
 ```
-
-<!-- TODO: write an update guide for v0.6.0 when it is going to be released:
-- clone operator
-- remove it
-- script to replace the old labels with new one
-- change the settings
- -->
 
 ## 0.2.1 and below
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -8,24 +8,42 @@ If your version is not included, just follow [Simple update](#simple-update)
 
 ## Simple update
 
-Export the version you want to use:
+Remove the operator:
 
 ```bash
-export IMG=cnwan/cnwan-operator:v0.3.0
+./scripts/remove.sh
 ```
 
-If you intend to use your own build you will have to modify the value of `IMG` above accordingly.
+and follow installation guide again. The operator will try to perform all its work again but will stop it when it realizes that most of it was already performed on previous installation.
 
-Run:
+## 0.5.1 and below
+
+Remove the operator:
 
 ```bash
-kubectl set image deployment/cnwan-operator-controller-manager -n cnwan-operator-system manager=$IMG --record
+./scripts/remove.sh
 ```
 
-and you should see
+`monitorNamespacesByDefault` on the settings needs to be set as `true` if your previous value of `namespace.listPolicy` was `blocklist`, otherwise you can just leave it as it is.
+
+Now, if your previous value of `namespace.listPolicy` was `allowlist` run:
 
 ```bash
-deployment.apps/cnwan-operator-controller-manager image updated
+for ns in $(kubectl get ns -l "operator.cnwan.io/allowed" -o jsonpath="{.items[*].metadata.name}")
+do
+kubectl label ns $ns operator.cnwan.io/monitor=true
+kubectl label ns $ns operator.cnwan.io/allowed-
+done
+```
+
+Or, if it was `blocklist`:
+
+```bash
+for ns in $(kubectl get ns -l "operator.cnwan.io/blocked" -o jsonpath="{.items[*].metadata.name}")
+do
+kubectl label ns $ns operator.cnwan.io/monitor=false
+kubectl label ns $ns operator.cnwan.io/blocked-
+done
 ```
 
 <!-- TODO: write an update guide for v0.6.0 when it is going to be released:

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -21,17 +21,7 @@ type Settings struct {
 	MonitorNamespacesByDefault bool            `yaml:"monitorNamespacesByDefault"`
 	Service                    ServiceSettings `yaml:",inline"`
 	*ServiceRegistrySettings   `yaml:"serviceRegistry"`
-
-	// DEPRECATED: include this under serviceRegistry instead of here.
-	// TODO: remove this on v0.6.0
-	Gcloud        *GcloudSettings `yaml:"gcloud"`
-	CloudMetadata *CloudMetadata  `yaml:"cloudMetadata"`
-}
-
-// GcloudSettings holds gcloud settings
-// TODO: remove this on v0.6.0
-type GcloudSettings struct {
-	ServiceDirectory *DeprecatedServiceDirectorySettings `yaml:"serviceDirectory"`
+	CloudMetadata              *CloudMetadata `yaml:"cloudMetadata"`
 }
 
 // ServiceSettings includes settings about services
@@ -44,13 +34,6 @@ type ServiceSettings struct {
 type ServiceRegistrySettings struct {
 	*ServiceDirectorySettings `yaml:"gcpServiceDirectory"`
 	*EtcdSettings             `yaml:"etcd"`
-}
-
-// DeprecatedServiceDirectorySettings holds settings about gcloud service directory
-// TODO: remove this on v0.6.0
-type DeprecatedServiceDirectorySettings struct {
-	DefaultRegion string `yaml:"region"`
-	ProjectName   string `yaml:"project"`
 }
 
 // ServiceDirectorySettings holds settings about gcloud service directory

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -18,10 +18,10 @@ package types
 
 // Settings of the application
 type Settings struct {
-	MonitorNamespacesByDefault bool            `yaml:"monitorNamespacesByDefault"`
-	Service                    ServiceSettings `yaml:",inline"`
-	*ServiceRegistrySettings   `yaml:"serviceRegistry"`
-	CloudMetadata              *CloudMetadata `yaml:"cloudMetadata"`
+	WatchNamespacesByDefault bool            `yaml:"watchNamespacesByDefault"`
+	Service                  ServiceSettings `yaml:",inline"`
+	*ServiceRegistrySettings `yaml:"serviceRegistry"`
+	CloudMetadata            *CloudMetadata `yaml:"cloudMetadata"`
 }
 
 // ServiceSettings includes settings about services

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -38,7 +38,7 @@ func ParseAndValidateSettings(settings *types.Settings) (*types.Settings, error)
 		return nil, fmt.Errorf("no settings provided")
 	}
 
-	finalSettings := &types.Settings{MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault}
+	finalSettings := &types.Settings{WatchNamespacesByDefault: settings.WatchNamespacesByDefault}
 	if settings.CloudMetadata != nil {
 		clCfg := settings.CloudMetadata
 		finalCfg := &types.CloudMetadata{}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -68,23 +68,6 @@ func ParseAndValidateSettings(settings *types.Settings) (*types.Settings, error)
 
 	// Only one service registry can be chosen at this time
 
-	// TODO: remove this in v0.6.0
-	if settings.Gcloud != nil {
-		if settings.Gcloud.ServiceDirectory != nil && settings.ServiceDirectorySettings == nil {
-			// Convert the deprecated service directory settings into the new structure,
-			// but only if the new one doesn't already exist.
-			log.V(int(zapcore.WarnLevel)).Info(`DEPRECATED: current service directory settings is under gcloud field.
-				This is deprecated and will be removed on v0.6.0.
-				Please place it under service registry as defined in the documentation.`)
-
-			sd := settings.Gcloud.ServiceDirectory
-			settings.ServiceDirectorySettings = &types.ServiceDirectorySettings{
-				DefaultRegion: sd.DefaultRegion,
-				ProjectID:     sd.ProjectName,
-			}
-		}
-	}
-
 	if settings.EtcdSettings == nil && settings.ServiceDirectorySettings == nil {
 		// Both are nil
 		return nil, fmt.Errorf("no service registry provided")

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -176,75 +176,8 @@ func TestParseAndValidateSettings(t *testing.T) {
 			},
 		},
 		{
-			id: "convert-deprecated-sd",
-			arg: &types.Settings{
-				Gcloud: &types.GcloudSettings{
-					ServiceDirectory: &types.DeprecatedServiceDirectorySettings{
-						ProjectName:   "test",
-						DefaultRegion: "ca",
-					},
-				},
-				MonitorNamespacesByDefault: true,
-				Service: types.ServiceSettings{
-					Annotations: []string{"one", "two"},
-				},
-				ServiceRegistrySettings: &types.ServiceRegistrySettings{},
-			},
-			expRes: &types.Settings{
-				MonitorNamespacesByDefault: true,
-				Service: types.ServiceSettings{
-					Annotations: []string{"one", "two"},
-				},
-				ServiceRegistrySettings: &types.ServiceRegistrySettings{
-					ServiceDirectorySettings: &types.ServiceDirectorySettings{
-						ProjectID:     "test",
-						DefaultRegion: "ca",
-					},
-				},
-			},
-		},
-		{
-			id: "do-not-convert-deprecated-sd",
-			arg: &types.Settings{
-				Gcloud: &types.GcloudSettings{
-					ServiceDirectory: &types.DeprecatedServiceDirectorySettings{
-						ProjectName:   "old",
-						DefaultRegion: "old",
-					},
-				},
-				MonitorNamespacesByDefault: true,
-				Service: types.ServiceSettings{
-					Annotations: []string{"one", "two"},
-				},
-				ServiceRegistrySettings: &types.ServiceRegistrySettings{
-					ServiceDirectorySettings: &types.ServiceDirectorySettings{
-						ProjectID:     "new",
-						DefaultRegion: "new",
-					},
-				},
-			},
-			expRes: &types.Settings{
-				MonitorNamespacesByDefault: true,
-				Service: types.ServiceSettings{
-					Annotations: []string{"one", "two"},
-				},
-				ServiceRegistrySettings: &types.ServiceRegistrySettings{
-					ServiceDirectorySettings: &types.ServiceDirectorySettings{
-						ProjectID:     "new",
-						DefaultRegion: "new",
-					},
-				},
-			},
-		},
-		{
 			id: "successful-with-cloud-cfg",
 			arg: &types.Settings{
-				Gcloud: &types.GcloudSettings{
-					ServiceDirectory: &types.DeprecatedServiceDirectorySettings{
-						ProjectName:   "old",
-						DefaultRegion: "old",
-					},
-				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -288,12 +221,6 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "successful-with-empty-cloud-cfg",
 			arg: &types.Settings{
-				Gcloud: &types.GcloudSettings{
-					ServiceDirectory: &types.DeprecatedServiceDirectorySettings{
-						ProjectName:   "old",
-						DefaultRegion: "old",
-					},
-				},
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -42,14 +42,14 @@ func TestParseAndValidateSettings(t *testing.T) {
 		},
 		{
 			id:     "no-service-registry-settings",
-			arg:    &types.Settings{MonitorNamespacesByDefault: true},
+			arg:    &types.Settings{WatchNamespacesByDefault: true},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
 		{
 			id: "no-service-registry-fields",
 			arg: &types.Settings{
-				MonitorNamespacesByDefault: true,
-				ServiceRegistrySettings:    &types.ServiceRegistrySettings{},
+				WatchNamespacesByDefault: true,
+				ServiceRegistrySettings:  &types.ServiceRegistrySettings{},
 			},
 			expErr: fmt.Errorf("no service registry provided"),
 		},
@@ -70,7 +70,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "etcd-uname-pass-auth",
 			arg: &types.Settings{
-				MonitorNamespacesByDefault: true,
+				WatchNamespacesByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -81,7 +81,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				MonitorNamespacesByDefault: true,
+				WatchNamespacesByDefault: true,
 				ServiceRegistrySettings: &types.ServiceRegistrySettings{
 					EtcdSettings: &types.EtcdSettings{
 						Authentication: types.EtcdAuthWithUsernamePassw,
@@ -148,7 +148,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 		{
 			id: "both-but-only-etcd-is-there",
 			arg: &types.Settings{
-				MonitorNamespacesByDefault: true,
+				WatchNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},
@@ -162,7 +162,7 @@ func TestParseAndValidateSettings(t *testing.T) {
 				},
 			},
 			expRes: &types.Settings{
-				MonitorNamespacesByDefault: true,
+				WatchNamespacesByDefault: true,
 				Service: types.ServiceSettings{
 					Annotations: []string{"one", "two"},
 				},

--- a/main.go
+++ b/main.go
@@ -199,24 +199,24 @@ func main() {
 	}
 
 	if err = (&controllers.ServiceReconciler{
-		Client:                     mgr.GetClient(),
-		Log:                        ctrl.Log.WithName("controllers").WithName("Service"),
-		Scheme:                     mgr.GetScheme(),
-		ServRegBroker:              srBroker,
-		MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault,
-		AllowedAnnotations:         settings.Service.Annotations,
+		Client:                   mgr.GetClient(),
+		Log:                      ctrl.Log.WithName("controllers").WithName("Service"),
+		Scheme:                   mgr.GetScheme(),
+		ServRegBroker:            srBroker,
+		WatchNamespacesByDefault: settings.WatchNamespacesByDefault,
+		AllowedAnnotations:       settings.Service.Annotations,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		returnCode = 8
 		runtime.Goexit()
 	}
 	if err = (&controllers.NamespaceReconciler{
-		Client:                     mgr.GetClient(),
-		Log:                        ctrl.Log.WithName("controllers").WithName("Namespace"),
-		Scheme:                     mgr.GetScheme(),
-		ServRegBroker:              srBroker,
-		MonitorNamespacesByDefault: settings.MonitorNamespacesByDefault,
-		AllowedAnnotations:         settings.Service.Annotations,
+		Client:                   mgr.GetClient(),
+		Log:                      ctrl.Log.WithName("controllers").WithName("Namespace"),
+		Scheme:                   mgr.GetScheme(),
+		ServRegBroker:            srBroker,
+		WatchNamespacesByDefault: settings.WatchNamespacesByDefault,
+		AllowedAnnotations:       settings.Service.Annotations,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 		returnCode = 9

--- a/scripts/remove.sh
+++ b/scripts/remove.sh
@@ -18,7 +18,13 @@ if [ "$(ls -A $DEPLOY_DIR/other)" ]; then
     echo "removing resources from 'other' directory..."
     kubectl delete -f $DEPLOY_DIR/other
 fi;
-kubectl delete deployment cnwan-operator-controller-manager -n cnwan-operator-system
+
+# The name of the deployment has been moved to just "cnwan-operator", so these
+# two lines delete both the old name and the new one and make sure to not exit
+# the operator in case they were not found.
+# TODO: remove this v0.8.0 or v0.9.0
+kubectl delete deployment cnwan-operator-controller-manager -n cnwan-operator-system || true
+kubectl delete deployment cnwan-operator -n cnwan-operator-system || true
 kubectl delete rolebinding cnwan-operator-rolebinding -n cnwan-operator-system
 kubectl delete role cnwan-operator-role -n cnwan-operator-system
 kubectl delete clusterrolebinding cnwan-operator-cluster-rolebinding


### PR DESCRIPTION
This PR performs the following:

- permanently removes features that were deprecated 2 major versions before (the old `gcloud` settings basically)
- creates a guide on how to update to v0.6.0