### PR TITLE
Add `SPDX-License-Identifier: Apache-2.0` to headers

### DIFF
--- a/controllers/doc.go
+++ b/controllers/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/types/doc.go
+++ b/internal/types/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/utils/doc.go
+++ b/internal/utils/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cluster/doc.go
+++ b/pkg/cluster/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cluster/kubernetes_test.go
+++ b/pkg/cluster/kubernetes_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cluster/network.go
+++ b/pkg/cluster/network.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/doc.go
+++ b/pkg/servregistry/aws/cloudmap/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/endpoint.go
+++ b/pkg/servregistry/aws/cloudmap/endpoint.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/endpoint_test.go
+++ b/pkg/servregistry/aws/cloudmap/endpoint_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/fake_client.go
+++ b/pkg/servregistry/aws/cloudmap/fake_client.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/handler.go
+++ b/pkg/servregistry/aws/cloudmap/handler.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/namespace.go
+++ b/pkg/servregistry/aws/cloudmap/namespace.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/namespace_test.go
+++ b/pkg/servregistry/aws/cloudmap/namespace_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/service.go
+++ b/pkg/servregistry/aws/cloudmap/service.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/service_test.go
+++ b/pkg/servregistry/aws/cloudmap/service_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/utils.go
+++ b/pkg/servregistry/aws/cloudmap/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/aws/cloudmap/utils_test.go
+++ b/pkg/servregistry/aws/cloudmap/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/broker.go
+++ b/pkg/servregistry/broker.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/broker_test.go
+++ b/pkg/servregistry/broker_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/data.go
+++ b/pkg/servregistry/data.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/doc.go
+++ b/pkg/servregistry/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/endpoint.go
+++ b/pkg/servregistry/endpoint.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/endpoint_test.go
+++ b/pkg/servregistry/endpoint_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/errors.go
+++ b/pkg/servregistry/errors.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/doc.go
+++ b/pkg/servregistry/etcd/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/endpoint.go
+++ b/pkg/servregistry/etcd/endpoint.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/endpoint_test.go
+++ b/pkg/servregistry/etcd/endpoint_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/errors.go
+++ b/pkg/servregistry/etcd/errors.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/example_key_test.go
+++ b/pkg/servregistry/etcd/example_key_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/example_test.go
+++ b/pkg/servregistry/etcd/example_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/fake_kv.go
+++ b/pkg/servregistry/etcd/fake_kv.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/key.go
+++ b/pkg/servregistry/etcd/key.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/key_test.go
+++ b/pkg/servregistry/etcd/key_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/namespace.go
+++ b/pkg/servregistry/etcd/namespace.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/namespace_test.go
+++ b/pkg/servregistry/etcd/namespace_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/service.go
+++ b/pkg/servregistry/etcd/service.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/service_registry.go
+++ b/pkg/servregistry/etcd/service_registry.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/service_registry_test.go
+++ b/pkg/servregistry/etcd/service_registry_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/service_test.go
+++ b/pkg/servregistry/etcd/service_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/utils.go
+++ b/pkg/servregistry/etcd/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/etcd/utils_test.go
+++ b/pkg/servregistry/etcd/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/doc.go
+++ b/pkg/servregistry/gcloud/servicedirectory/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/endpoint.go
+++ b/pkg/servregistry/gcloud/servicedirectory/endpoint.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/endpoint_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/endpoint_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/fake_reg_client_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/fake_reg_client_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/namespace.go
+++ b/pkg/servregistry/gcloud/servicedirectory/namespace.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/namespace_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/namespace_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/registration_client_interface.go
+++ b/pkg/servregistry/gcloud/servicedirectory/registration_client_interface.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/service.go
+++ b/pkg/servregistry/gcloud/servicedirectory/service.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/service_directory_handler.go
+++ b/pkg/servregistry/gcloud/servicedirectory/service_directory_handler.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/service_directory_handler_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/service_directory_handler_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/service_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/service_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/utils.go
+++ b/pkg/servregistry/gcloud/servicedirectory/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/gcloud/servicedirectory/utils_test.go
+++ b/pkg/servregistry/gcloud/servicedirectory/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/namespace.go
+++ b/pkg/servregistry/namespace.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/namespace_test.go
+++ b/pkg/servregistry/namespace_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/service.go
+++ b/pkg/servregistry/service.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/service_registry.go
+++ b/pkg/servregistry/service_registry.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/service_test.go
+++ b/pkg/servregistry/service_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/servregistry/utils.go
+++ b/pkg/servregistry/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
See https://github.com/CloudNativeSDWAN/cnwan-docs/discussions/4

Signed-off-by: Lori Jakab <lojakab@cisco.com>